### PR TITLE
Fix overflow bug

### DIFF
--- a/contracts/SetToken.sol
+++ b/contracts/SetToken.sol
@@ -71,7 +71,8 @@ contract SetToken is StandardToken, DetailedERC20("", "", 18), Set {
       uint currentUnits = units[i];
 
       // The transaction will fail if any of the tokens fail to transfer
-      assert(ERC20(currentToken).transferFrom(msg.sender, this, currentUnits * quantity));
+      uint transferValue = SafeMath.mul(currentUnits, quantity);
+      assert(ERC20(currentToken).transferFrom(msg.sender, this, transferValue));
     }
 
     // If successful, increment the balance of the user’s {Set} token
@@ -107,7 +108,8 @@ contract SetToken is StandardToken, DetailedERC20("", "", 18), Set {
       uint currentUnits = units[i];
 
       // The transaction will fail if any of the tokens fail to transfer
-      assert(ERC20(currentToken).transfer(msg.sender, currentUnits * quantity));
+      uint transferValue = SafeMath.mul(currentUnits, quantity);
+      assert(ERC20(currentToken).transfer(msg.sender, transferValue));
     }
 
     LogRedemption(msg.sender, quantity);

--- a/test/setToken.js
+++ b/test/setToken.js
@@ -41,7 +41,7 @@ contract('{Set}', function(accounts) {
 
     it('should not allow creation of a {Set} with no inputs', async () => {
       return expectedExceptionPromise(
-        () => SetToken.new([], [], { from: testAccount }),
+        () => SetToken.new([], [], name, symbol, { from: testAccount }),
         3000000,
       );
     });


### PR DESCRIPTION
This could be used to drain a contract of its collateral by issuing a large quantity at once to trigger an overflow, then redeeming smaller amounts.