### PR TITLE
Create CoreWrapper abstraction for DRYing up test setup

### DIFF
--- a/test/constants/constants.ts
+++ b/test/constants/constants.ts
@@ -1,9 +1,10 @@
 import { BigNumber } from "bignumber.js";
 import { ether, gWei } from "../utils/units";
 
+export const DEFAULT_GAS = 7000000;
 export const INVALID_OPCODE = "invalid opcode";
-export const REVERT_ERROR = "revert";
 export const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+export const REVERT_ERROR = "revert";
 export const STANDARD_INITIAL_TOKENS: BigNumber = ether(100000000000);
 export const STANDARD_QUANTITY_ISSUED: BigNumber = ether(10);
 export const STANDARD_NATURAL_UNIT = ether(1);

--- a/test/utils/coreWrapper.ts
+++ b/test/utils/coreWrapper.ts
@@ -1,0 +1,132 @@
+import * as _ from "lodash";
+
+import { AuthorizableContract } from "../../types/generated/authorizable";
+import { StandardTokenContract } from "../../types/generated/standard_token";
+import { StandardTokenMockContract } from "../../types/generated/standard_token_mock";
+import { StandardTokenWithFeeMockContract } from "../../types/generated/standard_token_with_fee_mock";
+import { TransferProxyContract } from "../../types/generated/transfer_proxy";
+
+import { BigNumber } from "bignumber.js";
+import { Address } from "../../types/common.js";
+
+import {
+  DEFAULT_GAS,
+  STANDARD_INITIAL_TOKENS,
+  UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
+} from "../constants/constants";
+
+// Artifacts
+const TransferProxy = artifacts.require("TransferProxy");
+const StandardTokenMock = artifacts.require("StandardTokenMock");
+const StandardTokenWithFeeMock = artifacts.require("StandardTokenWithFeeMock");
+
+export class CoreWrapper {
+  private _tokenOwnerAddress: Address;
+  private _contractOwnerAddress: Address;
+
+  constructor(tokenOwnerAddress: Address, contractOwnerAddress: Address) {
+    this._tokenOwnerAddress = tokenOwnerAddress;
+    this._contractOwnerAddress = contractOwnerAddress;
+  }
+
+  // Deploying Contracts
+
+  public async deployTokenAsync(
+    initialAccount: Address,
+    from: Address = this._tokenOwnerAddress
+  ): Promise<StandardTokenMockContract> {
+    const truffleMockToken = await StandardTokenMock.new(
+      initialAccount,
+      STANDARD_INITIAL_TOKENS,
+      "Mock Token",
+      "MOCK",
+      { from, gas: DEFAULT_GAS },
+    );
+
+    const mockTokenWeb3Contract = web3.eth
+      .contract(truffleMockToken.abi)
+      .at(truffleMockToken.address);
+
+    return new StandardTokenMockContract(
+      mockTokenWeb3Contract,
+      { from },
+    );
+  }
+
+  public async deployTokenWithFeeAsync(
+    fee: BigNumber,
+    initialAccount: Address,
+    from: Address = this._tokenOwnerAddress
+  ): Promise<StandardTokenWithFeeMockContract> {
+    const truffleMockTokenWithFee = await StandardTokenWithFeeMock.new(
+      initialAccount,
+      STANDARD_INITIAL_TOKENS,
+      `Mock Token With Fee`,
+      `FEE`,
+      fee,
+      { from, gas: DEFAULT_GAS },
+    );
+
+    const mockTokenWithFeeWeb3Contract = web3.eth
+      .contract(truffleMockTokenWithFee.abi)
+      .at(truffleMockTokenWithFee.address);
+
+    return new StandardTokenWithFeeMockContract(
+      mockTokenWithFeeWeb3Contract,
+      { from },
+    );
+  }
+
+  public async deployTransferProxyAsync(
+    vaultAddress: Address,
+    from: Address = this._tokenOwnerAddress
+  ): Promise<TransferProxyContract> {
+    const truffleTransferProxy = await TransferProxy.new(
+      { from, gas: DEFAULT_GAS },
+    );
+
+    const transferProxyWeb3Contract = web3.eth
+      .contract(truffleTransferProxy.abi)
+      .at(truffleTransferProxy.address);
+
+    const transferProxy = new TransferProxyContract(
+      transferProxyWeb3Contract,
+      { from, gas: DEFAULT_GAS },
+    );
+
+    // Set TransferProxy dependencies
+    await transferProxy.setVaultAddress.sendTransactionAsync(
+      vaultAddress,
+      { from },
+    );
+
+    return transferProxy;
+  }
+
+  // ERC20 Transactions
+
+  public async approveTransferAsync(
+    token: StandardTokenContract,
+    to: Address,
+    from: Address = this._tokenOwnerAddress
+  ) {
+    await token.approve.sendTransactionAsync(
+      to,
+      UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
+      { from },
+    );
+  }
+
+  // Authorizable
+
+  public async addAuthorizationAsync(
+    contract: AuthorizableContract,
+    toAuthorize: Address,
+    from: Address = this._contractOwnerAddress
+  ) {
+    await contract.addAuthorizedAddress.sendTransactionAsync(
+      toAuthorize,
+      { from },
+    );
+  }
+}


### PR DESCRIPTION
Abstracting out some of the test setup into a CoreWrapper class to clean up some of the spec files. In the future there should be logical groupings/other wrappers (ERC20, Authorizable methods for example)

Currently only applied to `transferProxy.spec.ts`, let me know your thoughts and we can apply to other spec files.