### PR TITLE
Alex/core wrapper abstraction

### DIFF
--- a/test/core/extensions/coreAccounting.spec.ts
+++ b/test/core/extensions/coreAccounting.spec.ts
@@ -18,6 +18,7 @@ import { VaultContract } from "../../../types/generated/vault";
 
 // Core wrapper
 import { CoreWrapper } from "../../utils/coreWrapper";
+import { ERC20Wrapper } from "../../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../../config/bigNumberSetup";
@@ -42,7 +43,6 @@ contract("CoreAccounting", (accounts) => {
     otherAccount,
     unauthorizedAccount,
   ] = accounts;
-  const TX_DEFAULTS = { from: ownerAccount, gas: 7000000 };
 
   let core: CoreContract;
   let mockToken: StandardTokenMockContract;
@@ -52,6 +52,7 @@ contract("CoreAccounting", (accounts) => {
   let setTokenFactory: SetTokenFactoryContract;
 
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+  const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
   const setCoreDependencies = async (from: Address = ownerAccount) => {
     await core.setVaultAddress.sendTransactionAsync(
@@ -94,8 +95,8 @@ contract("CoreAccounting", (accounts) => {
     beforeEach(async () => {
       await deployCoreAndInitializeDependencies();
 
-      mockToken = await coreWrapper.deployTokenAsync(tokenOwner);
-      await coreWrapper.approveTransferAsync(mockToken, transferProxy.address, approver);
+      mockToken = await erc20Wrapper.deployTokenAsync(tokenOwner);
+      await erc20Wrapper.approveTransferAsync(mockToken, transferProxy.address, approver);
     });
 
     let amountToDeposit = DEPLOYED_TOKEN_QUANTITY;
@@ -188,8 +189,8 @@ contract("CoreAccounting", (accounts) => {
     beforeEach(async () => {
       await deployCoreAndInitializeDependencies();
 
-      mockToken = await coreWrapper.deployTokenAsync(tokenOwner);
-      await coreWrapper.approveTransferAsync(mockToken, transferProxy.address, approver);
+      mockToken = await erc20Wrapper.deployTokenAsync(tokenOwner);
+      await erc20Wrapper.approveTransferAsync(mockToken, transferProxy.address, approver);
       await coreWrapper.depositFromUser(core, mockToken.address, ownerBalanceInVault);
     });
 
@@ -272,7 +273,7 @@ contract("CoreAccounting", (accounts) => {
     beforeEach(async () => {
       await deployCoreAndInitializeDependencies();
 
-      mockTokens = await coreWrapper.deployTokensAsync(tokenCount, tokenOwner);
+      mockTokens = await erc20Wrapper.deployTokensAsync(tokenCount, tokenOwner);
       const approvePromises = _.map(mockTokens, (token) =>
         token.approve.sendTransactionAsync(
           transferProxy.address,
@@ -305,26 +306,26 @@ contract("CoreAccounting", (accounts) => {
     }
 
     it("transfers the correct amount of each token from the caller", async () => {
-      const existingTokenBalances = await coreWrapper.getTokenBalances(mockTokens, ownerAccount);
+      const existingTokenBalances = await erc20Wrapper.getTokenBalances(mockTokens, ownerAccount);
       const expectedNewBalances = _.map(existingTokenBalances, (balance) =>
         balance.sub(DEPLOYED_TOKEN_QUANTITY),
       );
 
       await subject();
 
-      const newTokenBalances = await await coreWrapper.getTokenBalances(mockTokens, ownerAccount);
+      const newTokenBalances = await await erc20Wrapper.getTokenBalances(mockTokens, ownerAccount);
       expect(newTokenBalances).to.eql(expectedNewBalances);
     });
 
     it("transfers the correct amount of each token to the vault", async () => {
-      const existingTokenBalances = await coreWrapper.getTokenBalances(mockTokens, vault.address);
+      const existingTokenBalances = await erc20Wrapper.getTokenBalances(mockTokens, vault.address);
       const expectedNewBalances = _.map(existingTokenBalances, (balance) =>
         balance.add(DEPLOYED_TOKEN_QUANTITY),
       );
 
       await subject();
 
-      const newTokenBalances = await coreWrapper.getTokenBalances(mockTokens, vault.address);
+      const newTokenBalances = await erc20Wrapper.getTokenBalances(mockTokens, vault.address);
       expect(newTokenBalances).to.eql(expectedNewBalances);
     });
 
@@ -403,7 +404,7 @@ contract("CoreAccounting", (accounts) => {
     beforeEach(async () => {
       await deployCoreAndInitializeDependencies();
 
-      mockTokens = await coreWrapper.deployTokensAsync(tokenCount, tokenOwner);
+      mockTokens = await erc20Wrapper.deployTokensAsync(tokenCount, tokenOwner);
       const approvePromises = _.map(mockTokens, (token) =>
         token.approve.sendTransactionAsync(
           transferProxy.address,
@@ -443,26 +444,26 @@ contract("CoreAccounting", (accounts) => {
     }
 
     it("transfers the correct amount of each token from the caller", async () => {
-      const existingTokenBalances = await coreWrapper.getTokenBalances(mockTokens, ownerAccount);
+      const existingTokenBalances = await erc20Wrapper.getTokenBalances(mockTokens, ownerAccount);
       const expectedNewBalances = _.map(existingTokenBalances, (balance) =>
         balance.add(DEPLOYED_TOKEN_QUANTITY),
       );
 
       await subject();
 
-      const newTokenBalances = await await coreWrapper.getTokenBalances(mockTokens, ownerAccount);
+      const newTokenBalances = await await erc20Wrapper.getTokenBalances(mockTokens, ownerAccount);
       expect(newTokenBalances).to.eql(expectedNewBalances);
     });
 
     it("transfers the correct amount of each token to the vault", async () => {
-      const existingTokenBalances = await await coreWrapper.getTokenBalances(mockTokens, vault.address);
+      const existingTokenBalances = await await erc20Wrapper.getTokenBalances(mockTokens, vault.address);
       const expectedNewBalances = _.map(existingTokenBalances, (balance) =>
         balance.sub(DEPLOYED_TOKEN_QUANTITY),
       );
 
       await subject();
 
-      const newTokenBalances = await coreWrapper.getTokenBalances(mockTokens, vault.address);
+      const newTokenBalances = await erc20Wrapper.getTokenBalances(mockTokens, vault.address);
       expect(newTokenBalances).to.eql(expectedNewBalances);
     });
 

--- a/test/core/extensions/coreFactory.spec.ts
+++ b/test/core/extensions/coreFactory.spec.ts
@@ -62,21 +62,6 @@ contract("CoreFactory", (accounts) => {
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
   const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
-  // TODO: Leaving this setup modular right now so we can toggle the deployers, authorizers, etc. if we want.
-  // If we decide later that we don't need to, then we can move the abstracted setup functions into this one.
-  const deployCoreAndInitializeDependencies = async (from: Address = ownerAccount) => {
-    core = await coreWrapper.deployCoreAsync();
-
-    setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
-    await coreWrapper.addAuthorizationAsync(setTokenFactory, core.address);
-    await coreWrapper.setCoreAddress(setTokenFactory, core.address);
-
-    await core.enableFactory.sendTransactionAsync(
-      setTokenFactory.address,
-      { from },
-    );
-  };
-
   before(async () => {
     ABIDecoder.addABI(Core.abi);
   });
@@ -87,6 +72,10 @@ contract("CoreFactory", (accounts) => {
 
   beforeEach(async () => {
     core = await coreWrapper.deployCoreAsync();
+    setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
+    await coreWrapper.addAuthorizationAsync(setTokenFactory, core.address);
+    await coreWrapper.setCoreAddress(setTokenFactory, core.address);
+    await coreWrapper.enableFactoryAsync(core, setTokenFactory);
   });
 
   describe("#create", async () => {
@@ -99,7 +88,6 @@ contract("CoreFactory", (accounts) => {
     const symbol = "SET";
 
     beforeEach(async () => {
-      await deployCoreAndInitializeDependencies();
       mockToken = await erc20Wrapper.deployTokenAsync(ownerAccount);
 
       factoryAddress = setTokenFactory.address;

--- a/test/core/extensions/coreFactory.spec.ts
+++ b/test/core/extensions/coreFactory.spec.ts
@@ -19,6 +19,7 @@ const Core = artifacts.require("Core");
 
 // Core wrapper
 import { CoreWrapper } from "../../utils/coreWrapper";
+import { ERC20Wrapper } from "../../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../../config/bigNumberSetup";
@@ -59,6 +60,7 @@ contract("CoreFactory", (accounts) => {
   let setTokenFactory: SetTokenFactoryContract;
 
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+  const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
   // TODO: Leaving this setup modular right now so we can toggle the deployers, authorizers, etc. if we want.
   // If we decide later that we don't need to, then we can move the abstracted setup functions into this one.
@@ -98,7 +100,7 @@ contract("CoreFactory", (accounts) => {
 
     beforeEach(async () => {
       await deployCoreAndInitializeDependencies();
-      mockToken = await coreWrapper.deployTokenAsync(ownerAccount);
+      mockToken = await erc20Wrapper.deployTokenAsync(ownerAccount);
 
       factoryAddress = setTokenFactory.address;
       components = [mockToken.address];

--- a/test/core/extensions/coreInternal.spec.ts
+++ b/test/core/extensions/coreInternal.spec.ts
@@ -173,9 +173,7 @@ contract("CoreInternal", (accounts) => {
 
     beforeEach(async () => {
       setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
-      await core.enableFactory.sendTransactionAsync(setTokenFactory.address, {
-        from: ownerAccount,
-      });
+      await coreWrapper.enableFactoryAsync(core, setTokenFactory);
 
       subjectCaller = ownerAccount;
     });
@@ -211,28 +209,9 @@ contract("CoreInternal", (accounts) => {
 
     beforeEach(async () => {
       vault = await coreWrapper.deployVaultAsync();
-      await coreWrapper.addAuthorizationAsync(vault, core.address);
-
       transferProxy = await coreWrapper.deployTransferProxyAsync(vault.address);
-      await coreWrapper.addAuthorizationAsync(transferProxy, core.address);
-
       setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
-      await coreWrapper.addAuthorizationAsync(setTokenFactory, core.address);
-      await coreWrapper.setCoreAddress(setTokenFactory, core.address);
-
-      await core.setVaultAddress.sendTransactionAsync(
-          vault.address,
-          { from: ownerAccount },
-      );
-      await core.setTransferProxyAddress.sendTransactionAsync(
-          transferProxy.address,
-          { from: ownerAccount },
-      );
-
-      await core.enableFactory.sendTransactionAsync(
-        setTokenFactory.address,
-        { from: ownerAccount },
-      );
+      await coreWrapper.setDefaultStateAndAuthorizationsAsync(core, vault, transferProxy, setTokenFactory);
 
       const components = await erc20Wrapper.deployTokensAsync(2, ownerAccount);
       const componentAddresses = _.map(components, (token) => token.address);
@@ -243,8 +222,6 @@ contract("CoreInternal", (accounts) => {
         componentAddresses,
         componentUnits,
         STANDARD_NATURAL_UNIT,
-        "Set Token",
-        "SET",
       );
 
       subjectCaller = ownerAccount;

--- a/test/core/extensions/coreInternal.spec.ts
+++ b/test/core/extensions/coreInternal.spec.ts
@@ -21,6 +21,7 @@ const Core = artifacts.require("Core");
 
 // Core wrapper
 import { CoreWrapper } from "../../utils/coreWrapper";
+import { ERC20Wrapper } from "../../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../../config/bigNumberSetup";
@@ -49,6 +50,7 @@ contract("CoreInternal", (accounts) => {
   let setTokenFactory: SetTokenFactoryContract;
 
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+  const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
   before(async () => {
     ABIDecoder.addABI(Core.abi);
@@ -232,7 +234,7 @@ contract("CoreInternal", (accounts) => {
         { from: ownerAccount },
       );
 
-      const components = await coreWrapper.deployTokensAsync(2, ownerAccount);
+      const components = await erc20Wrapper.deployTokensAsync(2, ownerAccount);
       const componentAddresses = _.map(components, (token) => token.address);
       const componentUnits = _.map(components, () => STANDARD_NATURAL_UNIT); // Multiple of naturalUnit
       setToken = await coreWrapper.createSetTokenAsync(

--- a/test/core/extensions/coreIssuance.spec.ts
+++ b/test/core/extensions/coreIssuance.spec.ts
@@ -21,6 +21,7 @@ const Core = artifacts.require("Core");
 
 // Core wrapper
 import { CoreWrapper } from "../../utils/coreWrapper";
+import { ERC20Wrapper } from "../../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../../config/bigNumberSetup";
@@ -64,6 +65,7 @@ contract("CoreIssuance", (accounts) => {
   let setTokenFactory: SetTokenFactoryContract;
 
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+  const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
   const deployCoreAndInitializeDependencies = async () => {
     core = await coreWrapper.deployCoreAsync();
@@ -114,8 +116,8 @@ contract("CoreIssuance", (accounts) => {
     beforeEach(async () => {
       await deployCoreAndInitializeDependencies();
 
-      components = await coreWrapper.deployTokensAsync(2, ownerAccount);
-      await coreWrapper.approveTransfersAsync(components, transferProxy.address);
+      components = await erc20Wrapper.deployTokensAsync(2, ownerAccount);
+      await erc20Wrapper.approveTransfersAsync(components, transferProxy.address);
 
       const componentAddresses = _.map(components, (token) => token.address);
       componentUnits = _.map(components, () => ether(4)); // Multiple of naturalUnit
@@ -385,8 +387,8 @@ contract("CoreIssuance", (accounts) => {
     beforeEach(async () => {
       await deployCoreAndInitializeDependencies();
 
-      components = await coreWrapper.deployTokensAsync(2, ownerAccount);
-      await coreWrapper.approveTransfersAsync(components, transferProxy.address);
+      components = await erc20Wrapper.deployTokensAsync(2, ownerAccount);
+      await erc20Wrapper.approveTransfersAsync(components, transferProxy.address);
 
       const componentAddresses = _.map(components, (token) => token.address);
       componentUnits = _.map(components, () => naturalUnit.mul(2)); // Multiple of naturalUnit

--- a/test/core/setToken.spec.ts
+++ b/test/core/setToken.spec.ts
@@ -22,6 +22,7 @@ const StandardTokenWithFeeMock = artifacts.require("StandardTokenWithFeeMock");
 
 // Core wrapper
 import { CoreWrapper } from "../utils/coreWrapper";
+import { ERC20Wrapper } from "../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../config/bigNumberSetup";
@@ -58,6 +59,7 @@ contract("SetToken", (accounts) => {
   let factory: SetTokenFactoryContract;
 
   const coreWrapper = new CoreWrapper(deployerAccount, deployerAccount);
+  const erc20Wrapper = new ERC20Wrapper(deployerAccount);
 
   before(async () => {
     // Initialize ABI Decoders for deciphering log receipts
@@ -78,7 +80,7 @@ contract("SetToken", (accounts) => {
     const componentCount: number = 3;
 
     beforeEach(async () => {
-      components = await coreWrapper.deployTokensAsync(componentCount, deployerAccount);
+      components = await erc20Wrapper.deployTokensAsync(componentCount, deployerAccount);
       factory = await coreWrapper.deploySetTokenFactoryAsync();
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
@@ -238,7 +240,7 @@ contract("SetToken", (accounts) => {
     describe("when a component does not implement decimals() and natural unit lower", async () => {
       beforeEach(async () => {
         const minNaturalUnit = 10 ** 18;
-        const noDecimalToken = await coreWrapper.deployTokenWithNoDecimalAsync(deployerAccount);
+        const noDecimalToken = await erc20Wrapper.deployTokenWithNoDecimalAsync(deployerAccount);
         subjectComponentAddresses.push(noDecimalToken.address);
         subjectComponentUnits.push(STANDARD_COMPONENT_UNIT);
 
@@ -257,7 +259,7 @@ contract("SetToken", (accounts) => {
     let subjectCaller: Address = coreAccount;
 
     beforeEach(async () => {
-      components = await coreWrapper.deployTokensAsync(3, deployerAccount);
+      components = await erc20Wrapper.deployTokensAsync(3, deployerAccount);
       factory = await coreWrapper.deploySetTokenFactoryAsync();
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
@@ -321,7 +323,7 @@ contract("SetToken", (accounts) => {
     let subjectCaller: Address;
 
     beforeEach(async () => {
-      components = await coreWrapper.deployTokensAsync(3, deployerAccount);
+      components = await erc20Wrapper.deployTokensAsync(3, deployerAccount);
       factory = await coreWrapper.deploySetTokenFactoryAsync();
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
@@ -410,7 +412,7 @@ contract("SetToken", (accounts) => {
 
     beforeEach(async () => {
       const quantityToMint = ether(5);
-      components = await coreWrapper.deployTokensAsync(3, deployerAccount);
+      components = await erc20Wrapper.deployTokensAsync(3, deployerAccount);
       factory = await coreWrapper.deploySetTokenFactoryAsync();
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
@@ -482,7 +484,7 @@ contract("SetToken", (accounts) => {
 
     beforeEach(async () => {
       const quantityToMint = ether(5);
-      components = await coreWrapper.deployTokensAsync(3, deployerAccount);
+      components = await erc20Wrapper.deployTokensAsync(3, deployerAccount);
       factory = await coreWrapper.deploySetTokenFactoryAsync();
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
@@ -503,7 +505,7 @@ contract("SetToken", (accounts) => {
         { from: coreAccount },
       );
 
-      await coreWrapper.approveTransferAsync(setToken, deployerAccount, deployerAccount);
+      await erc20Wrapper.approveTransferAsync(setToken, deployerAccount, deployerAccount);
 
       subjectCaller = deployerAccount;
       subjectTokenReceiver = otherAccount;

--- a/test/core/setToken.spec.ts
+++ b/test/core/setToken.spec.ts
@@ -62,7 +62,6 @@ contract("SetToken", (accounts) => {
   const erc20Wrapper = new ERC20Wrapper(deployerAccount);
 
   before(async () => {
-    // Initialize ABI Decoders for deciphering log receipts
     ABIDecoder.addABI(SetToken.abi);
   });
 
@@ -76,7 +75,6 @@ contract("SetToken", (accounts) => {
     let subjectNaturalUnit: BigNumber;
     const subjectName: string = "Set Token";
     const subjectSymbol: string = "SET";
-
     const componentCount: number = 3;
 
     beforeEach(async () => {

--- a/test/core/setTokenFactory.spec.ts
+++ b/test/core/setTokenFactory.spec.ts
@@ -17,6 +17,7 @@ const SetTokenFactory = artifacts.require("SetTokenFactory");
 
 // Core wrapper
 import { CoreWrapper } from "../utils/coreWrapper";
+import { ERC20Wrapper } from "../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../config/bigNumberSetup";
@@ -39,6 +40,7 @@ contract("SetTokenFactory", (accounts) => {
   let setTokenFactory: SetTokenFactoryContract;
 
   const coreWrapper = new CoreWrapper(deployerAccount, deployerAccount);
+  const erc20Wrapper = new ERC20Wrapper(deployerAccount);
 
   before(async () => {
     ABIDecoder.addABI(SetTokenFactory.abi);
@@ -74,9 +76,7 @@ contract("SetTokenFactory", (accounts) => {
 
     describe("when there is one component", async () => {
       beforeEach(async () => {
-        const deployedComponent: StandardTokenMockContract = await coreWrapper.deployTokenAsync(
-          deployerAccount,
-        );
+        const deployedComponent: StandardTokenMockContract = await erc20Wrapper.deployTokenAsync(deployerAccount);
 
         components = [deployedComponent.address];
         units = [new BigNumber(1)];

--- a/test/core/transferProxy.spec.ts
+++ b/test/core/transferProxy.spec.ts
@@ -18,6 +18,7 @@ const TransferProxy = artifacts.require("TransferProxy");
 
 // Core wrapper
 import { CoreWrapper } from "../utils/coreWrapper";
+import { ERC20Wrapper } from "../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../config/bigNumberSetup";
@@ -42,6 +43,7 @@ contract("TransferProxy", (accounts) => {
   let transferProxy: TransferProxyContract;
 
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+  const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
   before(async () => {
     ABIDecoder.addABI(TransferProxy.abi);
@@ -95,8 +97,8 @@ contract("TransferProxy", (accounts) => {
       transferProxy = await coreWrapper.deployTransferProxyAsync(vaultAccount);
       await coreWrapper.addAuthorizationAsync(transferProxy, authorizedContract);
 
-      mockToken = await coreWrapper.deployTokenAsync(tokenOwner);
-      await coreWrapper.approveTransferAsync(mockToken, transferProxy.address, approver);
+      mockToken = await erc20Wrapper.deployTokenAsync(tokenOwner);
+      await erc20Wrapper.approveTransferAsync(mockToken, transferProxy.address, approver);
     });
 
     // Subject
@@ -161,12 +163,12 @@ contract("TransferProxy", (accounts) => {
       let mockTokenWithFee: StandardTokenWithFeeMockContract;
 
       before(async () => {
-        mockTokenWithFee = await coreWrapper.deployTokenWithFeeAsync(ownerAccount);
+        mockTokenWithFee = await erc20Wrapper.deployTokenWithFeeAsync(ownerAccount);
         tokenAddress = mockTokenWithFee.address;
       });
 
       beforeEach(async () => {
-        await coreWrapper.approveTransferAsync(mockTokenWithFee, transferProxy.address, ownerAccount);
+        await erc20Wrapper.approveTransferAsync(mockTokenWithFee, transferProxy.address, ownerAccount);
       });
 
       it("should revert", async () => {

--- a/test/core/vault.spec.ts
+++ b/test/core/vault.spec.ts
@@ -18,6 +18,7 @@ const Vault = artifacts.require("Vault");
 
 // Core wrapper
 import { CoreWrapper } from "../utils/coreWrapper";
+import { ERC20Wrapper } from "../utils/erc20Wrapper";
 
 // Testing Set up
 import { BigNumberSetup } from "../config/bigNumberSetup";
@@ -41,6 +42,7 @@ contract("Vault", (accounts) => {
   let vault: VaultContract;
 
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+  const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
   before(async () => {
     ABIDecoder.addABI(Vault.abi);
@@ -61,7 +63,7 @@ contract("Vault", (accounts) => {
       vault = await coreWrapper.deployVaultAsync();
       await coreWrapper.addAuthorizationAsync(vault, authorizedAccount);
 
-      mockToken = await coreWrapper.deployTokenAsync(vault.address);
+      mockToken = await erc20Wrapper.deployTokenAsync(vault.address);
       await coreWrapper.incrementAccountBalanceAsync(
         vault,
         ownerAccount,
@@ -113,7 +115,7 @@ contract("Vault", (accounts) => {
 
     describe("when working with a bad ERC20 token", async () => {
       beforeEach(async () => {
-        mockToken = await coreWrapper.deployTokenWithInvalidBalancesAsync(vault.address);
+        mockToken = await erc20Wrapper.deployTokenWithInvalidBalancesAsync(vault.address);
         subjectTokenAddress = mockToken.address;
       });
 
@@ -166,7 +168,7 @@ contract("Vault", (accounts) => {
       let mockTokenWithFee: StandardTokenWithFeeMockContract;
 
       beforeEach(async () => {
-        mockTokenWithFee = await coreWrapper.deployTokenWithFeeAsync(ownerAccount);
+        mockTokenWithFee = await erc20Wrapper.deployTokenWithFeeAsync(ownerAccount);
         subjectTokenAddress = mockTokenWithFee.address;
       });
 
@@ -308,7 +310,7 @@ contract("Vault", (accounts) => {
       vault = await coreWrapper.deployVaultAsync();
       await coreWrapper.addAuthorizationAsync(vault, authorizedAccount);
 
-      mockToken = await coreWrapper.deployTokenAsync(vault.address);
+      mockToken = await erc20Wrapper.deployTokenAsync(vault.address);
       await coreWrapper.incrementAccountBalanceAsync(
         vault,
         ownerAccount,

--- a/test/core/vault.spec.ts
+++ b/test/core/vault.spec.ts
@@ -13,13 +13,6 @@ import { StandardTokenMockContract } from "../../types/generated/standard_token_
 import { StandardTokenWithFeeMockContract } from "../../types/generated/standard_token_with_fee_mock";
 import { VaultContract } from "../../types/generated/vault";
 
-// Artifacts
-const Vault = artifacts.require("Vault");
-
-// Core wrapper
-import { CoreWrapper } from "../utils/coreWrapper";
-import { ERC20Wrapper } from "../utils/erc20Wrapper";
-
 // Testing Set up
 import { BigNumberSetup } from "../config/bigNumberSetup";
 import ChaiSetup from "../config/chaiSetup";
@@ -27,6 +20,8 @@ BigNumberSetup.configure();
 ChaiSetup.configure();
 const { expect, assert } = chai;
 
+import { CoreWrapper } from "../utils/coreWrapper";
+import { ERC20Wrapper } from "../utils/erc20Wrapper";
 import { assertTokenBalance, expectRevertError } from "../utils/tokenAssertions";
 import { DEPLOYED_TOKEN_QUANTITY, NULL_ADDRESS, ZERO } from "../utils/constants";
 
@@ -43,14 +38,6 @@ contract("Vault", (accounts) => {
 
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
   const erc20Wrapper = new ERC20Wrapper(ownerAccount);
-
-  before(async () => {
-    ABIDecoder.addABI(Vault.abi);
-  });
-
-  after(async () => {
-    ABIDecoder.removeABI(Vault.abi);
-  });
 
   describe("#withdrawTo", async () => {
     let subjectAmountToWithdraw: BigNumber = DEPLOYED_TOKEN_QUANTITY;

--- a/test/utils/coreWrapper.ts
+++ b/test/utils/coreWrapper.ts
@@ -133,7 +133,47 @@ export class CoreWrapper {
     );
   }
 
+  // Internal
+
+  public async enableFactoryAsync(
+    core: CoreContract,
+    setTokenFactory: SetTokenFactoryContract,
+    from: Address = this._contractOwnerAddress,
+  ) {
+    await core.enableFactory.sendTransactionAsync(
+      setTokenFactory.address,
+      { from }
+    );
+  }
+
   // Authorizable
+
+  public async setDefaultStateAndAuthorizationsAsync(
+    core: CoreContract,
+    vault: VaultContract,
+    transferProxy: TransferProxyContract,
+    setTokenFactory: SetTokenFactoryContract,
+    from: Address = this._tokenOwnerAddress,
+  ) {
+    this.addAuthorizationAsync(vault, core.address);
+    this.addAuthorizationAsync(transferProxy, core.address);
+    this.addAuthorizationAsync(setTokenFactory, core.address);
+    this.setCoreAddress(setTokenFactory, core.address);
+
+    await core.setVaultAddress.sendTransactionAsync(
+        vault.address,
+        { from },
+    );
+    await core.setTransferProxyAddress.sendTransactionAsync(
+        transferProxy.address,
+        { from },
+    );
+
+    await core.enableFactory.sendTransactionAsync(
+      setTokenFactory.address,
+      { from },
+    );
+  }
 
   public async addAuthorizationAsync(
     contract: AuthorizableContract,
@@ -180,27 +220,14 @@ export class CoreWrapper {
 
   // Core
 
-  public async depositFromUser(
-    core: CoreContract,
-    token: Address,
-    quantity: BigNumber,
-    from: Address = this._contractOwnerAddress,
-  ) {
-    await core.deposit.sendTransactionAsync(
-      token,
-      quantity,
-      { from },
-    );
-  }
-
   public async createSetTokenAsync(
     core: CoreContract,
     factory: Address,
     componentAddresses: Address[],
     units: BigNumber[],
     naturalUnit: BigNumber,
-    name: string,
-    symbol: string,
+    name: string = "Set Token",
+    symbol: string = "SET",
     from: Address = this._tokenOwnerAddress,
   ): Promise<SetTokenContract> {
     const txHash = await core.create.sendTransactionAsync(
@@ -220,6 +247,19 @@ export class CoreWrapper {
       setAddress,
       web3,
       { from }
+    );
+  }
+
+  public async depositFromUser(
+    core: CoreContract,
+    token: Address,
+    quantity: BigNumber,
+    from: Address = this._contractOwnerAddress,
+  ) {
+    await core.deposit.sendTransactionAsync(
+      token,
+      quantity,
+      { from },
     );
   }
 

--- a/test/utils/erc20Wrapper.ts
+++ b/test/utils/erc20Wrapper.ts
@@ -1,0 +1,167 @@
+import * as _ from "lodash";
+
+import { BadTokenMockContract } from "../../types/generated/bad_token_mock";
+import { StandardTokenMockContract } from "../../types/generated/standard_token_mock";
+import { StandardTokenWithFeeMockContract } from "../../types/generated/standard_token_with_fee_mock";
+import { NoDecimalTokenMockContract } from "../../types/generated/no_decimal_token_mock";
+
+import { BigNumber } from "bignumber.js";
+import { Address } from "../../types/common.js";
+import {
+  DEFAULT_GAS,
+  DEFAULT_MOCK_TOKEN_DECIMALS,
+  DEPLOYED_TOKEN_QUANTITY,
+  UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
+} from "../utils/constants";
+import { randomIntegerLessThan } from "../utils/math";
+
+const BadTokenMock = artifacts.require("BadTokenMock");
+const StandardTokenMock = artifacts.require("StandardTokenMock");
+const StandardTokenWithFeeMock = artifacts.require("StandardTokenWithFeeMock");
+const NoDecimalTokenMock = artifacts.require("NoDecimalTokenMock");
+
+
+export class ERC20Wrapper {
+  private _senderAccountAddress: Address;
+
+  constructor(senderAccountAddress: Address) {
+    this._senderAccountAddress = senderAccountAddress;
+  }
+
+  public async deployTokenAsync(
+    initialAccount: Address
+  ): Promise<StandardTokenMockContract> {
+    const truffleMockToken = await StandardTokenMock.new(
+      initialAccount,
+      DEPLOYED_TOKEN_QUANTITY,
+      "Mock Token",
+      "MOCK",
+      DEFAULT_MOCK_TOKEN_DECIMALS,
+      { from: this._senderAccountAddress, gas: DEFAULT_GAS },
+    );
+
+    return new StandardTokenMockContract(
+      web3.eth.contract(truffleMockToken.abi).at(truffleMockToken.address),
+      { from: this._senderAccountAddress },
+    );
+  }
+
+  public async deployTokensAsync(
+    tokenCount: number,
+    initialAccount: Address,
+  ): Promise<StandardTokenMockContract[]> {
+    const mockTokens: StandardTokenMockContract[] = [];
+
+    const mockTokenPromises = _.times(tokenCount, (index) => {
+      return StandardTokenMock.new(
+        initialAccount,
+        DEPLOYED_TOKEN_QUANTITY,
+        `Component ${index}`,
+        index,
+        randomIntegerLessThan(18, 4),
+        { from: this._senderAccountAddress, gas: DEFAULT_GAS },
+      );
+    });
+
+    await Promise.all(mockTokenPromises).then((tokenMock) => {
+      _.each(tokenMock, (standardToken) => {
+        mockTokens.push(new StandardTokenMockContract(
+          web3.eth.contract(standardToken.abi).at(standardToken.address),
+          { from: this._senderAccountAddress }
+        ));
+      });
+    });
+
+    return mockTokens;
+  }
+
+  public async deployTokenWithFeeAsync(
+    initialAccount: Address,
+    fee: BigNumber = new BigNumber(100)
+  ): Promise<StandardTokenWithFeeMockContract> {
+    const truffleMockTokenWithFee = await StandardTokenWithFeeMock.new(
+      initialAccount,
+      DEPLOYED_TOKEN_QUANTITY,
+      `Mock Token With Fee`,
+      `FEE`,
+      fee,
+      { from: this._senderAccountAddress, gas: DEFAULT_GAS },
+    );
+
+    return new StandardTokenWithFeeMockContract(
+      web3.eth.contract(truffleMockTokenWithFee.abi).at(truffleMockTokenWithFee.address),
+      { from: this._senderAccountAddress },
+    );
+  }
+
+  public async deployTokenWithNoDecimalAsync(
+    initialAccount: Address,
+  ): Promise<NoDecimalTokenMockContract> {
+    const truffleMockToken = await NoDecimalTokenMock.new(
+      initialAccount,
+      DEPLOYED_TOKEN_QUANTITY,
+      "No Decimal Token",
+      "NDT",
+      { from: this._senderAccountAddress, gas: DEFAULT_GAS },
+    );
+
+    return new NoDecimalTokenMockContract(
+      web3.eth.contract(truffleMockToken.abi).at(truffleMockToken.address),
+      { from: this._senderAccountAddress },
+    );
+  }
+
+  public async deployTokenWithInvalidBalancesAsync(
+    initialAccount: Address
+  ): Promise<BadTokenMockContract> {
+    const truffleMockToken = await BadTokenMock.new(
+      initialAccount,
+      DEPLOYED_TOKEN_QUANTITY,
+      "Mock Token Bad Balances",
+      "BAD",
+      { from: this._senderAccountAddress, gas: DEFAULT_GAS },
+    );
+
+    return new BadTokenMockContract(
+      web3.eth.contract(truffleMockToken.abi).at(truffleMockToken.address),
+      { from: this._senderAccountAddress },
+    );
+  }
+
+  public async approveTransferAsync(
+    token: StandardTokenMockContract,
+    to: Address,
+    from: Address = this._senderAccountAddress,
+  ) {
+    await this.approveTransfersAsync([token], to, from);
+  }
+
+  public async approveTransfersAsync(
+    tokens: StandardTokenMockContract[],
+    to: Address,
+    from: Address = this._senderAccountAddress,
+  ) {
+    const approvePromises = _.map(tokens, (token) =>
+      token.approve.sendTransactionAsync(
+        to,
+        UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
+        { from },
+      ),
+    );
+    await Promise.all(approvePromises);
+  }
+
+  public async getTokenBalances(
+    tokens: StandardTokenMockContract[],
+    owner: Address,
+  ): Promise<BigNumber[]> {
+    const balancePromises = _.map(tokens, (token) => token.balanceOf.callAsync(owner));
+
+    let balances: BigNumber[];
+    await Promise.all(balancePromises).then((fetchedTokenBalances) => {
+      balances = fetchedTokenBalances;
+    });
+
+    return balances;
+  }
+}


### PR DESCRIPTION
- ERC20 Wrapper for various mock token deployments and approvals/transfers
- Removed all function definitions from test files (additional functions that abstracted common setup). DRY'd up and move into `coreWrapper.setDefaultStateAndAuthorizationsAsync`