### PR TITLE
Fix random number generation for decimals

### DIFF
--- a/test/core/setToken.spec.ts
+++ b/test/core/setToken.spec.ts
@@ -32,7 +32,6 @@ ChaiSetup.configure();
 const { expect, assert } = chai;
 
 import { getFormattedLogsFromTxHash } from "../logs/logUtils";
-import { randomIntegerLessThan } from "../utils/math";
 import { assertTokenBalance, expectRevertError } from "../utils/tokenAssertions";
 
 import {
@@ -83,7 +82,7 @@ contract("SetToken", (accounts) => {
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
       subjectComponentAddresses = _.map(components, (token) => token.address);
-      subjectComponentUnits = _.map(components, () => ether(randomIntegerLessThan(4)));
+      subjectComponentUnits = _.map(components, () => ether(_.random(1, 4)));
       subjectNaturalUnit = STANDARD_NATURAL_UNIT;
     });
 
@@ -262,14 +261,12 @@ contract("SetToken", (accounts) => {
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
       const componentAddresses = _.map(components, (token) => token.address);
-      const componentUnits = _.map(components, () => ether(randomIntegerLessThan(4)));
+      const componentUnits = _.map(components, () => ether(_.random(1, 4)));
       setToken = await coreWrapper.deploySetTokenAsync(
         factory.address,
         componentAddresses,
         componentUnits,
         STANDARD_NATURAL_UNIT,
-        "Set Token",
-        "SET",
       );
     });
 
@@ -326,14 +323,12 @@ contract("SetToken", (accounts) => {
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
       const componentAddresses = _.map(components, (token) => token.address);
-      const componentUnits = _.map(components, () => ether(randomIntegerLessThan(4)));
+      const componentUnits = _.map(components, () => ether(_.random(1, 4)));
       setToken = await coreWrapper.deploySetTokenAsync(
         factory.address,
         componentAddresses,
         componentUnits,
         STANDARD_NATURAL_UNIT,
-        "Set Token",
-        "SET",
       );
 
       await setToken.mint.sendTransactionAsync(
@@ -415,14 +410,12 @@ contract("SetToken", (accounts) => {
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
       const componentAddresses = _.map(components, (token) => token.address);
-      const componentUnits = _.map(components, () => ether(randomIntegerLessThan(4)));
+      const componentUnits = _.map(components, () => ether(_.random(1, 4)));
       setToken = await coreWrapper.deploySetTokenAsync(
         factory.address,
         componentAddresses,
         componentUnits,
         STANDARD_NATURAL_UNIT,
-        "Set Token",
-        "SET",
       );
 
       await setToken.mint.sendTransactionAsync(
@@ -487,14 +480,12 @@ contract("SetToken", (accounts) => {
       await coreWrapper.setCoreAddress(factory, coreAccount);
 
       const componentAddresses = _.map(components, (token) => token.address);
-      const componentUnits = _.map(components, () => ether(randomIntegerLessThan(4)));
+      const componentUnits = _.map(components, () => ether(_.random(1, 4)));
       setToken = await coreWrapper.deploySetTokenAsync(
         factory.address,
         componentAddresses,
         componentUnits,
         STANDARD_NATURAL_UNIT,
-        "Set Token",
-        "SET",
       );
 
       await setToken.mint.sendTransactionAsync(

--- a/test/utils/coreWrapper.ts
+++ b/test/utils/coreWrapper.ts
@@ -11,7 +11,6 @@ import { VaultContract } from "../../types/generated/vault";
 import { BigNumber } from "bignumber.js";
 import { Address } from "../../types/common.js";
 import { DEFAULT_GAS } from "../utils/constants";
-import { randomIntegerLessThan } from "../utils/math";
 import { getFormattedLogsFromTxHash } from "../logs/logUtils";
 import { extractNewSetTokenAddressFromLogs } from "../logs/contracts/core";
 
@@ -98,8 +97,8 @@ export class CoreWrapper {
     componentAddresses: Address[],
     units: BigNumber[],
     naturalUnit: BigNumber,
-    name: string,
-    symbol: string,
+    name: string = "Set Token",
+    symbol: string = "SET",
     from: Address = this._tokenOwnerAddress
   ): Promise<SetTokenContract> {
     const truffleSetToken = await SetToken.new(

--- a/test/utils/erc20Wrapper.ts
+++ b/test/utils/erc20Wrapper.ts
@@ -13,7 +13,6 @@ import {
   DEPLOYED_TOKEN_QUANTITY,
   UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
 } from "../utils/constants";
-import { randomIntegerLessThan } from "../utils/math";
 
 const BadTokenMock = artifacts.require("BadTokenMock");
 const StandardTokenMock = artifacts.require("StandardTokenMock");
@@ -58,7 +57,7 @@ export class ERC20Wrapper {
         DEPLOYED_TOKEN_QUANTITY,
         `Component ${index}`,
         index,
-        randomIntegerLessThan(18, 4),
+        _.random(4, 18),
         { from: this._senderAccountAddress, gas: DEFAULT_GAS },
       );
     });

--- a/test/utils/math.ts
+++ b/test/utils/math.ts
@@ -1,3 +1,0 @@
-export const randomIntegerLessThan = (lessThan: number, greaterThan: number = 0) => {
-  return Math.ceil(Math.random() * Math.floor(lessThan)) + greaterThan;
-};


### PR DESCRIPTION
Invalid logic used previously for generating random integers. Default to lodash's random number generator instead. This may have resulted in some incorrect decimals.