### PR TITLE
Clean up encoding files

### DIFF
--- a/test/contracts/core/exchange-wrappers/lib/zeroExOrderDataHandlerMock.spec.ts
+++ b/test/contracts/core/exchange-wrappers/lib/zeroExOrderDataHandlerMock.spec.ts
@@ -6,8 +6,8 @@ import * as ABIDecoder from "abi-decoder";
 import { BigNumber } from "bignumber.js";
 
 // Types
-import { Address, Bytes32, Log, UInt } from "../../../../../types/common.js";
-import { ZeroExSignature, ZeroExOrderHeader, ZeroExOrder } from "../../../../../types/zeroEx";
+import { Address, Bytes32, Log, UInt, Bytes } from "../../../../../types/common.js";
+import { ZeroExOrderHeader, ZeroExOrder } from "../../../../../types/zeroEx";
 
 // Contract types
 import { ZeroExOrderDataHandlerMockContract } from "../../../../../types/generated/zero_ex_order_data_handler_mock";
@@ -18,11 +18,14 @@ const ZeroExOrderDataHandlerMock = artifacts.require("ZeroExOrderDataHandlerMock
 import {
   bufferZeroExOrder,
   createZeroExOrder,
-  getZeroExOrderLengthFromBuffer,
   generateStandardZeroExOrderBytesArray,
   generateERC20TokenAssetData,
-  getNumBytesFromHex,
 } from "../../../../utils/zeroExExchangeWrapper";
+
+import {
+  getNumBytesFromHex,
+  getNumBytesFromBuffer
+} from "../../../../utils/encoding";
 
 // Testing Set up
 import { BigNumberSetup } from "../../../../utils/bigNumberSetup";
@@ -51,7 +54,7 @@ contract("ZeroExOrderDataHandlerMock", (accounts) => {
   let zeroExExchangeWrapper: ZeroExOrderDataHandlerMockContract;
 
   // Signature
-  let signature: ZeroExSignature = "ABCDEFgiHIJKLMNOPQRSTUVWXYZ";
+  let signature: Bytes = "0x0012034334393842";
 
   // 0x Order Subject Data
   let fillAmount = new BigNumber(5);
@@ -94,7 +97,7 @@ contract("ZeroExOrderDataHandlerMock", (accounts) => {
 
   describe("#parseOrderDataHeader", async () => {
     // Header Subject Data
-    let signatureLength: UInt;
+    let signatureLength: BigNumber;
     let zeroExOrderLength: BigNumber;
     let makerAssetDataLength: BigNumber;
     let takerAssetDataLength: BigNumber;
@@ -109,9 +112,9 @@ contract("ZeroExOrderDataHandlerMock", (accounts) => {
       );
 
       const zeroExOrderBuffer = bufferZeroExOrder(zeroExOrder);
-      zeroExOrderLength = getZeroExOrderLengthFromBuffer(zeroExOrderBuffer);
+      zeroExOrderLength = getNumBytesFromBuffer(zeroExOrderBuffer);
 
-      signatureLength = new BigNumber(signature.length);
+      signatureLength = getNumBytesFromHex(signature);
       makerAssetDataLength = getNumBytesFromHex(makerAssetData);
       takerAssetDataLength = getNumBytesFromHex(takerAssetData);
     });
@@ -168,7 +171,7 @@ contract("ZeroExOrderDataHandlerMock", (accounts) => {
 
     it("should correctly parse the signature", async () => {
       const signatureResult = await subject();
-      expect(web3.toAscii(signatureResult)).to.equal(signature);
+      expect(signatureResult).to.equal(signature);
     });
   });
 

--- a/test/contracts/core/exchange-wrappers/zeroExExchangeWrapper.spec.ts
+++ b/test/contracts/core/exchange-wrappers/zeroExExchangeWrapper.spec.ts
@@ -7,7 +7,7 @@ import { BigNumber } from "bignumber.js";
 
 // Types
 import { Address, Bytes32, Log, UInt } from "../../../../types/common.js";
-import { ZeroExSignature, ZeroExOrderHeader, ZeroExOrder } from "../../../../types/zeroEx";
+import { ZeroExOrderHeader, ZeroExOrder } from "../../../../types/zeroEx";
 
 // Contract types
 import { ZeroExExchangeWrapperContract } from "../../../../types/generated/zero_ex_exchange_wrapper";

--- a/test/utils/encoding.ts
+++ b/test/utils/encoding.ts
@@ -1,0 +1,93 @@
+import * as _ from "lodash";
+import * as ethUtil from "ethereumjs-util";
+import * as Web3 from "web3";
+const web3 = new Web3();
+
+import { BigNumber } from "bignumber.js";
+
+import { Address, Bytes32, Bytes, UInt } from "../../types/common.js";
+
+/**
+ * Returns a buffer padded to 32 bytes
+ * @param {any} any input to buffer
+ * @return {Buffer}
+ */
+export function bufferAndLPad32(input: any): Buffer {
+  return ethUtil.setLengthLeft(ethUtil.toBuffer(input), 32);
+}
+
+export function bufferArrayToHex(
+  bufferArr: Buffer[]
+): Bytes32 {
+    const buffer = Buffer.concat(bufferArr);
+    return ethUtil.bufferToHex(buffer);
+}
+
+export function bufferAndLPad32BigNumber(bigNum: BigNumber): Buffer {
+	return bufferAndLPad32(web3.toHex(bigNum));
+}
+
+/**
+ * Taken from: https://github.com/SilentCicero/strip-hex-prefix/blob/master/src/index.js
+ * Returns a big int of the num of bytes in the hex string
+ * @param {String} bytestring the string in bytes
+ * @return {String|Optional} a string by pass if necessary
+ */
+export function getNumBytesFromHex(hexString: string): BigNumber {
+	if (!isHexPrefixed(hexString)) {
+		throw new Error(`${hexString} is not a hex string. It must be Hex-Prefixed`);
+	}
+
+	return new BigNumber(removeHexPrefix(hexString).length).div(2);
+}
+
+export function getNumBytesFromBuffer(
+    buff: Buffer[],
+): BigNumber {
+    const hex = bufferArrayToHex(buff);
+    return getNumBytesFromHex(hex);
+}
+
+
+/**
+ * Taken from: https://github.com/SilentCicero/strip-hex-prefix/blob/master/src/index.js
+ * Removes '0x' from a given `String` if present
+ * @param {String} str the string value
+ * @return {String|Optional} a string by pass if necessary
+ */
+export function removeHexPrefix(input: any): string {
+  if (typeof input !== 'string') {
+    return input;
+  }
+
+  return isHexPrefixed(input) ? input.slice(2) : input;
+}
+
+/**
+ * Adds '0x' from a given `String` if not present
+ * @param {String} str the string value
+ * @return {String|Optional} a string by pass if necessary
+ */
+export function addHexPrefix(input: any): string {
+if (typeof input !== 'string') {
+    return input;
+  }
+
+  return !isHexPrefixed(input) ? `0x${input}` : input;
+}
+
+
+/**
+ * Taken from: https://github.com/SilentCicero/is-hex-prefixed/blob/master/src/index.js
+ * Returns a `Boolean` on whether or not the a `String` starts with '0x'
+ * @param {String} str the string input value
+ * @return {Boolean} a boolean if it is or is not hex prefixed
+ * @throws if the str input is not a string
+ */
+export function isHexPrefixed(str: any): boolean {
+  if (typeof str !== 'string') {
+    throw new Error("[is-hex-prefixed] value must be type 'string', is currently type " + (typeof str) + ", while checking isHexPrefixed.");
+  }
+
+  return str.slice(0, 2) === '0x';
+}

--- a/types/zeroEx.d.ts
+++ b/types/zeroEx.d.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from "bignumber.js";
 import { Address, Bytes, UInt } from "./common";
 
 export interface ZeroExOrderHeader {
@@ -12,14 +13,12 @@ export interface ZeroExOrder {
   takerAddress: Address;
   feeRecipientAddress: Address;
   senderAddress: Address;
-  makerAssetAmount: UInt;
-  takerAssetAmount: UInt;
-  makerFee: UInt;
-  takerFee: UInt;
-  expirationTimeSeconds: UInt;
-  salt: UInt;
+  makerAssetAmount: BigNumber;
+  takerAssetAmount: BigNumber;
+  makerFee: BigNumber;
+  takerFee: BigNumber;
+  expirationTimeSeconds: BigNumber;
+  salt: BigNumber;
   makerAssetData: Bytes;
   takerAssetData: Bytes;
 }
-
-export type ZeroExSignature = string;


### PR DESCRIPTION
- Moved all generic encoding methods into a separate Utils file
- Added more explicit naming for types and length calculations