### PR TITLE
Move vault and transferProxy settings into the Core constructor

### DIFF
--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -22,7 +22,7 @@ import { CoreFactory } from "./extensions/CoreFactory.sol";
 import { CoreInternal } from "./extensions/CoreInternal.sol";
 import { CoreIssuance } from "./extensions/CoreIssuance.sol";
 import { CoreIssuanceOrder } from "./extensions/CoreIssuanceOrder.sol";
-
+import { CoreState } from "./lib/CoreState.sol";
 
 
 /**
@@ -34,10 +34,30 @@ import { CoreIssuanceOrder } from "./extensions/CoreIssuanceOrder.sol";
  */
  /* solium-disable-next-line no-empty-blocks */
 contract Core is
+    CoreState,
     CoreExchangeDispatcher,
     CoreIssuanceOrder,
     CoreAccounting,
     CoreInternal,
     CoreFactory,
     CoreIssuance
-{}
+{
+    /**
+     * Constructor function for Core
+     *
+     * @param _transferProxy  The address of the transfer proxy
+     * @param _vault          The address of the vault  
+     */
+    constructor(
+        address _transferProxy,
+        address _vault
+    )
+        public
+    {
+        // Commit passed address to transferProxyAddress state variable
+        state.transferProxy = _transferProxy;
+
+        // Commit passed address to vault state variable
+        state.vault = _vault;
+    }
+}

--- a/contracts/core/extensions/CoreInternal.sol
+++ b/contracts/core/extensions/CoreInternal.sol
@@ -34,36 +34,6 @@ contract CoreInternal is
     /* ============ External Functions ============ */
 
     /**
-     * Set vaultAddress. Can only be set by owner of Core.
-     *
-     * @param  _vault   The address of the Vault
-     */
-    function setVaultAddress(
-        address _vault
-    )
-        external
-        onlyOwner
-    {
-        // Commit passed address to vaultAddress state variable
-        state.vault = _vault;
-    }
-
-    /**
-     * Set transferProxyAddress. Can only be set by owner of Core.
-     *
-     * @param  _transferProxy   The address of the TransferProxy
-     */
-    function setTransferProxyAddress(
-        address _transferProxy
-    )
-        external
-        onlyOwner
-    {
-        // Commit passed address to transferProxyAddress state variable
-        state.transferProxy = _transferProxy;
-    }
-
-    /**
      * Add a factory to the mapping of tracked factories. Can only be set by
      * owner of Core.
      *

--- a/migrations/2_core.js
+++ b/migrations/2_core.js
@@ -38,11 +38,15 @@ async function deployAndLinkLibraries(deployer, network) {
 
 async function deployCoreContracts(deployer, network) {
   await Promise.all([
-    deployer.deploy(Core),
     deployer.deploy(Vault),
     deployer.deploy(TransferProxy),
     deployer.deploy(SetTokenFactory)
   ]);
+
+  const transferProxy = await TransferProxy.deployed();
+  const vault = await Vault.deployed();
+
+  await deployer.deploy(Core, transferProxy.address, vault.address);
 
   await deployer.deploy(TakerWalletWrapper, TransferProxy.address);
   if (network === 'kovan' ) {
@@ -68,8 +72,6 @@ async function addAuthorizations(deployer, network) {
   await setTokenFactory.setCoreAddress(Core.address);
 
   const core = await Core.deployed();
-  await core.setVaultAddress(Vault.address);
-  await core.setTransferProxyAddress(TransferProxy.address);
   await core.enableFactory(SetTokenFactory.address);
   await core.registerExchange(EXCHANGES.TAKER_WALLET, TakerWalletWrapper.address);
   if (network === 'kovan' ) {

--- a/test/core/core.spec.ts
+++ b/test/core/core.spec.ts
@@ -1,0 +1,71 @@
+import * as ABIDecoder from 'abi-decoder';
+import * as chai from 'chai';
+import { Address } from 'set-protocol-utils';
+
+import ChaiSetup from '../../utils/chaiSetup';
+import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import {
+  CoreContract,
+  TransferProxyContract,
+  VaultContract,
+} from '../../utils/contracts';
+import { CoreWrapper } from '../../utils/coreWrapper';
+
+BigNumberSetup.configure();
+ChaiSetup.configure();
+const { expect } = chai;
+const Core = artifacts.require('Core');
+
+
+contract('Core', accounts => {
+  const [
+    ownerAccount,
+  ] = accounts;
+
+  let transferProxy: TransferProxyContract;
+  let vault: VaultContract;
+
+  const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+
+  before(async () => {
+    ABIDecoder.addABI(Core.abi);
+  });
+
+  after(async () => {
+    ABIDecoder.removeABI(Core.abi);
+  });
+
+  describe('#constructor', async () => {
+    // Setup
+    const subjectCaller: Address = ownerAccount;
+
+    beforeEach(async () => {
+      transferProxy = await coreWrapper.deployTransferProxyAsync();
+      vault = await coreWrapper.deployVaultAsync();
+    });
+
+    async function subject(): Promise<CoreContract> {
+      return await coreWrapper.deployCoreAsync(
+        transferProxy,
+        vault,
+        subjectCaller,
+      );
+    }
+
+    it('should contain the correct address of the transfer proxy', async () => {
+      const coreContract = await subject();
+
+      const proxyAddress = await coreContract.transferProxy.callAsync();
+
+      expect(proxyAddress).to.equal(transferProxy.address);
+    });
+
+    it('should contain the correct address of the vault', async () => {
+      const coreContract = await subject();
+
+      const vaultAddress = await coreContract.vault.callAsync();
+
+      expect(vaultAddress).to.equal(vault.address);
+    });
+  });
+});

--- a/test/core/extensions/coreAccounting.spec.ts
+++ b/test/core/extensions/coreAccounting.spec.ts
@@ -39,9 +39,9 @@ contract('CoreAccounting', accounts => {
   const erc20Wrapper = new ERC20Wrapper(ownerAccount);
 
   beforeEach(async () => {
-    core = await coreWrapper.deployCoreAsync();
     vault = await coreWrapper.deployVaultAsync();
     transferProxy = await coreWrapper.deployTransferProxyAsync();
+    core = await coreWrapper.deployCoreAsync(transferProxy, vault);
     setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
     await coreWrapper.setDefaultStateAndAuthorizationsAsync(core, vault, transferProxy, setTokenFactory);
   });

--- a/test/core/extensions/coreExchangeDispatcher.spec.ts
+++ b/test/core/extensions/coreExchangeDispatcher.spec.ts
@@ -38,7 +38,7 @@ contract('CoreExchangeDispatcher', accounts => {
   });
 
   beforeEach(async () => {
-    core = await coreWrapper.deployCoreAsync();
+    core = await coreWrapper.deployCoreAndDependenciesAsync();
   });
 
   describe('#registerExchange', async () => {

--- a/test/core/extensions/coreFactory.spec.ts
+++ b/test/core/extensions/coreFactory.spec.ts
@@ -39,7 +39,7 @@ contract('CoreFactory', accounts => {
   });
 
   beforeEach(async () => {
-    core = await coreWrapper.deployCoreAsync();
+    core = await coreWrapper.deployCoreAndDependenciesAsync();
     setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
     await coreWrapper.addAuthorizationAsync(setTokenFactory, core.address);
     await coreWrapper.setCoreAddress(setTokenFactory, core.address);

--- a/test/core/extensions/coreInternal.spec.ts
+++ b/test/core/extensions/coreInternal.spec.ts
@@ -49,77 +49,7 @@ contract('CoreInternal', accounts => {
   });
 
   beforeEach(async () => {
-    core = await coreWrapper.deployCoreAsync();
-  });
-
-  describe('#setVaultAddress', async () => {
-    let subjectCaller: Address;
-
-    beforeEach(async () => {
-      vault = await coreWrapper.deployVaultAsync();
-      await coreWrapper.addAuthorizationAsync(vault, core.address);
-
-      subjectCaller = ownerAccount;
-    });
-
-    async function subject(): Promise<string> {
-      return core.setVaultAddress.sendTransactionAsync(
-        vault.address,
-        { from: subjectCaller },
-      );
-    }
-
-    it('sets vault address correctly', async () => {
-      await subject();
-
-      const storedVaultAddress = await core.vault.callAsync();
-      expect(storedVaultAddress).to.eql(vault.address);
-    });
-
-    describe('when the caller is not the owner of the contract', async () => {
-      beforeEach(async () => {
-        subjectCaller = otherAccount;
-      });
-
-      it('should revert', async () => {
-        await expectRevertError(subject());
-      });
-    });
-  });
-
-  describe('#setTransferProxyAddress', async () => {
-    let subjectCaller: Address;
-
-    beforeEach(async () => {
-      vault = await coreWrapper.deployVaultAsync();
-      transferProxy = await coreWrapper.deployTransferProxyAsync();
-
-      subjectCaller = ownerAccount;
-    });
-
-    async function subject(): Promise<string> {
-      return core.setTransferProxyAddress.sendTransactionAsync(
-        transferProxy.address,
-        { from: subjectCaller },
-      );
-    }
-
-    it('sets transfer proxy address correctly', async () => {
-      await subject();
-
-      const storedTransferProxyAddress = await core.transferProxy.callAsync();
-      expect(storedTransferProxyAddress).to.eql(transferProxy.address);
-    });
-
-    describe('when the caller is not the owner of the contract', async () => {
-      beforeEach(async () => {
-        subjectCaller = otherAccount;
-      });
-
-      it('should revert', async () => {
-        await expectRevertError(subject());
-      });
-    });
+    core = await coreWrapper.deployCoreAndDependenciesAsync();
   });
 
   describe('#enableFactory', async () => {

--- a/test/core/extensions/coreIssuance.spec.ts
+++ b/test/core/extensions/coreIssuance.spec.ts
@@ -51,9 +51,9 @@ contract('CoreIssuance', accounts => {
   });
 
   beforeEach(async () => {
-    core = await coreWrapper.deployCoreAsync();
-    vault = await coreWrapper.deployVaultAsync();
     transferProxy = await coreWrapper.deployTransferProxyAsync();
+    vault = await coreWrapper.deployVaultAsync();
+    core = await coreWrapper.deployCoreAsync(transferProxy, vault);
     setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
     await coreWrapper.setDefaultStateAndAuthorizationsAsync(core, vault, transferProxy, setTokenFactory);
   });

--- a/test/core/extensions/coreIssuanceOrder.spec.ts
+++ b/test/core/extensions/coreIssuanceOrder.spec.ts
@@ -70,9 +70,9 @@ contract('CoreIssuanceOrder', accounts => {
   });
 
   beforeEach(async () => {
-    core = await coreWrapper.deployCoreAsync();
     vault = await coreWrapper.deployVaultAsync();
     transferProxy = await coreWrapper.deployTransferProxyAsync();
+    core = await coreWrapper.deployCoreAsync(transferProxy, vault);
     setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
     takerWalletWrapper = await exchangeWrapper.deployTakerWalletExchangeWrapper(transferProxy);
 

--- a/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
+++ b/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
@@ -60,9 +60,9 @@ contract('CoreIssuanceOrder::Scenarios', accounts => {
   });
 
   beforeEach(async () => {
-    core = await coreWrapper.deployCoreAsync();
     vault = await coreWrapper.deployVaultAsync();
     transferProxy = await coreWrapper.deployTransferProxyAsync();
+    core = await coreWrapper.deployCoreAsync(transferProxy, vault);
     setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync();
     takerWalletWrapper = await exchangeWrapper.deployTakerWalletExchangeWrapper(transferProxy);
 


### PR DESCRIPTION
First step is to move transfer proxy and vault setup to constructor.
- Add constructor on Core
- Update unit tests accordingly