### PR TITLE
Add Time-Bound Authorization settings

### DIFF
--- a/contracts/core/SetTokenFactory.sol
+++ b/contracts/core/SetTokenFactory.sol
@@ -38,7 +38,9 @@ contract SetTokenFactory
 
     /* ============ Constructor ============ */
     
-    constructor() Authorizable(4 weeks) {}
+    constructor() 
+        Authorizable(4 weeks)
+    {}
 
     /* ============ Setter Functions ============ */
 

--- a/contracts/core/SetTokenFactory.sol
+++ b/contracts/core/SetTokenFactory.sol
@@ -36,6 +36,10 @@ contract SetTokenFactory
     // Address of the Core contract
     address public core;
 
+    /* ============ Constructor ============ */
+    
+    constructor() Authorizable(4 weeks) {}
+
     /* ============ Setter Functions ============ */
 
     /**

--- a/contracts/core/TransferProxy.sol
+++ b/contracts/core/TransferProxy.sol
@@ -34,6 +34,10 @@ contract TransferProxy is
 {
     using SafeMath for uint256;
 
+    /* ============ Constructor ============ */
+    
+    constructor() Authorizable(4 weeks) {}
+
     /* ============ External Functions ============ */
 
     /**

--- a/contracts/core/TransferProxy.sol
+++ b/contracts/core/TransferProxy.sol
@@ -36,7 +36,9 @@ contract TransferProxy is
 
     /* ============ Constructor ============ */
     
-    constructor() Authorizable(4 weeks) {}
+    constructor()
+        Authorizable(4 weeks)
+    {}
 
     /* ============ External Functions ============ */
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -54,7 +54,9 @@ contract Vault is
 
     /* ============ Constructor ============ */
     
-    constructor() Authorizable(4 weeks) {}
+    constructor()
+        Authorizable(4 weeks)
+    {}
 
     /* ============ External Functions ============ */
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -52,6 +52,10 @@ contract Vault is
     // +--------------+---------------------+--------+
     mapping (address => mapping (address => uint256)) public balances;
 
+    /* ============ Constructor ============ */
+    
+    constructor() Authorizable(4 weeks) {}
+
     /* ============ External Functions ============ */
 
     /*

--- a/contracts/core/exchange-wrappers/TakerWalletWrapper.sol
+++ b/contracts/core/exchange-wrappers/TakerWalletWrapper.sol
@@ -50,6 +50,7 @@ contract TakerWalletWrapper is
         address _transferProxy
     )
         public
+        Authorizable(4 weeks)
     {
         // Set transferProxy address
         transferProxy = _transferProxy;

--- a/contracts/lib/Authorizable.sol
+++ b/contracts/lib/Authorizable.sol
@@ -35,8 +35,6 @@ contract Authorizable is
     /* ============ State Variables ============ */
 
     // Time in which authorized addresses can no longer be changed
-    // Currently hardcoded as 4 weeks
-    // uint256 public gracePeriodEnd = block.timestamp.add(4 weeks);
     uint256 public gracePeriodEnd;
 
     // Mapping of addresses to bool indicator of authorization
@@ -70,7 +68,6 @@ contract Authorizable is
     /* ============ Constructor ============ */
     
     /**
-     *
      * @param  _gracePeriod   Time period in which authorizations can be added or removed
      */
     constructor

--- a/contracts/lib/Authorizable.sol
+++ b/contracts/lib/Authorizable.sol
@@ -34,6 +34,10 @@ contract Authorizable is
 
     /* ============ State Variables ============ */
 
+    // Time in which authorized addresses can no longer be changed
+    // Currently hardcoded as 4 weeks
+    uint256 public gracePeriodEnd;
+
     // Mapping of addresses to bool indicator of authorization
     mapping (address => bool) public authorized;
 
@@ -62,6 +66,21 @@ contract Authorizable is
         address authorizedBy
     );
 
+    /* ============ Constructor ============ */
+    
+    /**
+     *
+     * @param  _gracePeriod   Time period in which authorizations can be added or removed
+     */
+    constructor
+    (
+        uint256 _gracePeriod
+    )
+        public 
+    {
+        gracePeriodEnd = block.timestamp.add(_gracePeriod);
+    }
+
     /* ============ Setters ============ */
 
     /**
@@ -74,6 +93,9 @@ contract Authorizable is
         external
         onlyOwner
     {
+        // Require that timestamp is before grace period
+        require(block.timestamp < gracePeriodEnd);
+
         // Require that address is not already authorized
         require(!authorized[_authTarget]);
 
@@ -100,6 +122,9 @@ contract Authorizable is
         external
         onlyOwner
     {
+        // Require that timestamp is before grace period
+        require(block.timestamp < gracePeriodEnd);
+
         // Require address is authorized
         require(authorized[_authTarget]); // Target address must be authorized.
 
@@ -141,6 +166,9 @@ contract Authorizable is
         external
         onlyOwner
     {
+        // Require that timestamp is before grace period
+        require(block.timestamp < gracePeriodEnd);
+        
         // Require index is less than length of authorities
         require(_index < authorities.length);
 

--- a/contracts/lib/Authorizable.sol
+++ b/contracts/lib/Authorizable.sol
@@ -36,6 +36,7 @@ contract Authorizable is
 
     // Time in which authorized addresses can no longer be changed
     // Currently hardcoded as 4 weeks
+    // uint256 public gracePeriodEnd = block.timestamp.add(4 weeks);
     uint256 public gracePeriodEnd;
 
     // Mapping of addresses to bool indicator of authorization

--- a/test/core/extensions/coreIssuanceOrder.spec.ts
+++ b/test/core/extensions/coreIssuanceOrder.spec.ts
@@ -33,6 +33,9 @@ import {
 import { CoreWrapper } from '../../../utils/coreWrapper';
 import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
 
+import { injectInTruffle } from 'sol-trace-set';
+injectInTruffle(web3, artifacts);
+
 BigNumberSetup.configure();
 ChaiSetup.configure();
 const utils = new Utils(web3);

--- a/test/core/extensions/coreIssuanceOrder.spec.ts
+++ b/test/core/extensions/coreIssuanceOrder.spec.ts
@@ -33,9 +33,6 @@ import {
 import { CoreWrapper } from '../../../utils/coreWrapper';
 import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
 
-import { injectInTruffle } from 'sol-trace-set';
-injectInTruffle(web3, artifacts);
-
 BigNumberSetup.configure();
 ChaiSetup.configure();
 const utils = new Utils(web3);

--- a/test/lib/authorizable.spec.ts
+++ b/test/lib/authorizable.spec.ts
@@ -117,7 +117,13 @@ contract('Authorizable', accounts => {
       const timeToIncrease = gracePeriod.plus(new BigNumber(1000)).toNumber();
 
       beforeEach(async () => {
+        await blockchain.saveSnapshotAsync();
+
         await blockchain.increaseTimeAsync(timeToIncrease);
+      });
+
+      afterEach(async () => {
+        await blockchain.revertAsync();
       });
 
       it('should revert', async () => {
@@ -311,7 +317,13 @@ contract('Authorizable', accounts => {
       const timeToIncrease = gracePeriod.plus(new BigNumber(1000)).toNumber();
 
       beforeEach(async () => {
+        await blockchain.saveSnapshotAsync();
+
         await blockchain.increaseTimeAsync(timeToIncrease);
+      });
+
+      afterEach(async () => {
+        await blockchain.revertAsync();
       });
 
       it('should revert', async () => {

--- a/test/lib/authorizable.spec.ts
+++ b/test/lib/authorizable.spec.ts
@@ -5,6 +5,7 @@ import { Address } from 'set-protocol-utils';
 
 import ChaiSetup from '../../utils/chaiSetup';
 import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import { Blockchain } from '../../utils/blockchain';
 import { AuthorizableContract } from '../../utils/contracts';
 import { assertLogEquivalence, getFormattedLogsFromTxHash } from '../../utils/logs';
 import { getExpectedAddAuthorizedLog, getExpectedRemoveAuthorizedLog } from '../../utils/contract_logs/authorizable';
@@ -17,6 +18,7 @@ const { expect } = chai;
 const Authorizable = artifacts.require('Authorizable');
 
 
+
 contract('Authorizable', accounts => {
   const [
     ownerAccount,
@@ -26,8 +28,10 @@ contract('Authorizable', accounts => {
     authAccount2,
   ] = accounts;
 
+  const gracePeriod: BigNumber = new BigNumber(2419200); // 4 weeks
   let authorizableContract: AuthorizableContract;
   const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+  const blockchain = new Blockchain(web3);
 
   before(async () => {
     ABIDecoder.addABI(Authorizable.abi);
@@ -41,7 +45,7 @@ contract('Authorizable', accounts => {
     let caller: Address = ownerAccount;
 
     beforeEach(async () => {
-      authorizableContract = await coreWrapper.deployAuthorizableAsync();
+      authorizableContract = await coreWrapper.deployAuthorizableAsync(gracePeriod);
     });
 
     afterEach(async () => {
@@ -108,6 +112,18 @@ contract('Authorizable', accounts => {
         await expectRevertError(subject());
       });
     });
+
+    describe('when the timestamp is beyond the grace period of 4 weeks', async () => {
+      const timeToIncrease = gracePeriod.plus(new BigNumber(1000)).toNumber();
+
+      beforeEach(async () => {
+        await blockchain.increaseTimeAsync(timeToIncrease);
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
   });
 
   describe('#removeAuthorizedAddress', async () => {
@@ -115,7 +131,7 @@ contract('Authorizable', accounts => {
     let addressToRemove: Address = authorizedAccount;
 
     beforeEach(async () => {
-      authorizableContract = await coreWrapper.deployAuthorizableAsync();
+      authorizableContract = await coreWrapper.deployAuthorizableAsync(gracePeriod);
 
       const authAccountArray: Address[] = [authAccount1, authAccount2, authorizedAccount];
       for (const account of authAccountArray) {
@@ -183,6 +199,24 @@ contract('Authorizable', accounts => {
         await expectRevertError(subject());
       });
     });
+
+    describe('when the timestamp is beyond the grace period of 4 weeks', async () => {
+      const timeToIncrease = gracePeriod.plus(new BigNumber(1000)).toNumber();
+
+      beforeEach(async () => {
+        await blockchain.saveSnapshotAsync();
+
+        await blockchain.increaseTimeAsync(timeToIncrease);
+      });
+
+      afterEach(async () => {
+        await blockchain.revertAsync();
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
   });
 
   describe('#removeAuthorizedAddressAtindexToRemove', async () => {
@@ -191,7 +225,7 @@ contract('Authorizable', accounts => {
     let indexToRemove: BigNumber = new BigNumber(2);
 
     beforeEach(async () => {
-      authorizableContract = await coreWrapper.deployAuthorizableAsync();
+      authorizableContract = await coreWrapper.deployAuthorizableAsync(gracePeriod);
 
       const authAccountArray: Address[] = [authAccount1, authAccount2, authorizedAccount];
       for (const account of authAccountArray) {
@@ -266,6 +300,18 @@ contract('Authorizable', accounts => {
     describe('when the passed indexToRemove does not match target address', async () => {
       beforeEach(async () => {
         indexToRemove = new BigNumber(1);
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+
+    describe('when the timestamp is beyond the grace period of 4 weeks', async () => {
+      const timeToIncrease = gracePeriod.plus(new BigNumber(1000)).toNumber();
+
+      beforeEach(async () => {
+        await blockchain.increaseTimeAsync(timeToIncrease);
       });
 
       it('should revert', async () => {

--- a/utils/coreWrapper.ts
+++ b/utils/coreWrapper.ts
@@ -33,6 +33,7 @@ export class CoreWrapper {
   private _contractOwnerAddress: Address;
   private _truffleOrderLibrary: any;
   private _truffleERC20Wrapper: any;
+  private _defaultGracePeriod = new BigNumber(2419200); // 4 Weeks
 
   constructor(tokenOwnerAddress: Address, contractOwnerAddress: Address) {
     this._tokenOwnerAddress = tokenOwnerAddress;
@@ -84,9 +85,11 @@ export class CoreWrapper {
   }
 
   public async deployAuthorizableAsync(
+    gracePeriod: BigNumber = this._defaultGracePeriod,
     from: Address = this._tokenOwnerAddress
   ): Promise<AuthorizableContract> {
     const truffleAuthorizable = await Authorizable.new(
+      gracePeriod,
       { from, gas: DEFAULT_GAS },
     );
 


### PR DESCRIPTION
- Authorized addresses of the vault, SetTokenFactory, TransferProxy, and TakerWalletWrapper can only be set for a month.
- Unit testing includes traversals and reversions of timestamp