### PR TITLE
[POC] Module Path Aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "fs-extra": "^5.0.0",
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
+    "module-alias": "^2.1.0",
     "set-protocol-utils": "^0.3.30",
     "sol-trace-set": "^0.0.1",
     "solium": "^1.1.7",
@@ -115,5 +116,8 @@
       "yarn lint-ts --fix",
       "git add"
     ]
+  },
+  "_moduleAliases": {
+    "@utils": "transpiled/utils"
   }
 }

--- a/test/core/core.spec.ts
+++ b/test/core/core.spec.ts
@@ -1,16 +1,18 @@
+require('module-alias/register');
+
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreContract,
   TransferProxyContract,
   VaultContract,
-} from '../../utils/contracts';
-import { Blockchain } from '../../utils/blockchain';
-import { CoreWrapper } from '../../utils/coreWrapper';
+} from '@utils/contracts';
+import { Blockchain } from '@utils/blockchain';
+import { CoreWrapper } from '@utils/coreWrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/exchange-wrappers/lib/zeroExOrderDataHandlerMock.spec.ts
+++ b/test/core/exchange-wrappers/lib/zeroExOrderDataHandlerMock.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as chai from 'chai';
 import * as setProtocolUtils from 'set-protocol-utils';
@@ -6,13 +8,13 @@ import { assetDataUtils } from '@0xproject/order-utils';
 import { BigNumber } from 'bignumber.js';
 import { Order as ZeroExOrder } from '@0xproject/types';
 
-import ChaiSetup from '../../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../../utils/bigNumberSetup';
-import { ZeroExOrderDataHandlerMockContract } from '../../../../utils/contracts';
-import { expectRevertError } from '../../../../utils/tokenAssertions';
-import { LibraryMockWrapper } from '../../../../utils/libraryMockWrapper';
-import { Blockchain } from '../../../../utils/blockchain';
-import { ether } from '../../../../utils/units';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { ZeroExOrderDataHandlerMockContract } from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { LibraryMockWrapper } from '@utils/libraryMockWrapper';
+import { Blockchain } from '@utils/blockchain';
+import { ether } from '@utils/units';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
+++ b/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
@@ -1,26 +1,28 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
 import { Address, Bytes } from 'set-protocol-utils';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   StandardTokenMockContract,
   TakerWalletWrapperContract,
   TransferProxyContract
-} from '../../../utils/contracts';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
-import { ExchangeWrapper } from '../../../utils/exchangeWrapper';
-import { Blockchain } from '../../../utils/blockchain';
-import { generateTakerWalletOrders } from '../../../utils/orders';
+} from '@utils/contracts';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
+import { ExchangeWrapper } from '@utils/exchangeWrapper';
+import { Blockchain } from '@utils/blockchain';
+import { generateTakerWalletOrders } from '@utils/orders';
 import {
   DEFAULT_GAS,
   DEPLOYED_TOKEN_QUANTITY,
   UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
-} from '../../../utils/constants';
-import { expectRevertError } from '../../../utils/tokenAssertions';
+} from '@utils/constants';
+import { expectRevertError } from '@utils/tokenAssertions';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/exchange-wrappers/zeroExExchangeWrapper.spec.ts
+++ b/test/core/exchange-wrappers/zeroExExchangeWrapper.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as chai from 'chai';
 import * as setProtocolUtils from 'set-protocol-utils';
@@ -5,23 +7,23 @@ import { BigNumber } from 'bignumber.js';
 import { Order as ZeroExOrder } from '@0xproject/types';
 import { Address, Bytes } from 'set-protocol-utils';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   StandardTokenMockContract,
   TransferProxyContract,
   ZeroExExchangeWrapperContract
-} from '../../../utils/contracts';
-import { expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
-import { ExchangeWrapper } from '../../../utils/exchangeWrapper';
+} from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
+import { ExchangeWrapper } from '@utils/exchangeWrapper';
 import {
   UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
   ZERO
-} from '../../../utils/constants';
-import { ether } from '../../../utils/units';
+} from '@utils/constants';
+import { ether } from '@utils/units';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreAccounting.spec.ts
+++ b/test/core/extensions/coreAccounting.spec.ts
@@ -1,26 +1,28 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreContract,
   SetTokenFactoryContract,
   StandardTokenMockContract,
   TransferProxyContract,
   VaultContract
-} from '../../../utils/contracts';
-import { assertTokenBalance, expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { CoreWrapper } from '../../../utils/coreWrapper';
+} from '@utils/contracts';
+import { assertTokenBalance, expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { CoreWrapper } from '@utils/coreWrapper';
 import {
   DEFAULT_GAS,
   DEPLOYED_TOKEN_QUANTITY,
   UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
-} from '../../../utils/constants';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
+} from '@utils/constants';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreExchangeDispatcher.spec.ts
+++ b/test/core/extensions/coreExchangeDispatcher.spec.ts
@@ -1,16 +1,18 @@
+require('module-alias/register');
+
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import * as setProtocolUtils from 'set-protocol-utils';
 import { Address, Log } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
-import { CoreContract } from '../../../utils/contracts';
-import { expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { ExchangeRegistered } from '../../../utils/contract_logs/core';
-import { CoreWrapper } from '../../../utils/coreWrapper';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { CoreContract } from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { ExchangeRegistered } from '@utils/contract_logs/core';
+import { CoreWrapper } from '@utils/coreWrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreFactory.spec.ts
+++ b/test/core/extensions/coreFactory.spec.ts
@@ -1,18 +1,20 @@
+require('module-alias/register');
+
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import * as setProtocolUtils from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 import { Address, Log, Bytes } from 'set-protocol-utils';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
-import { CoreContract, SetTokenFactoryContract, StandardTokenMockContract } from '../../../utils/contracts';
-import { expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { extractNewSetTokenAddressFromLogs, SetTokenCreated } from '../../../utils/contract_logs/core';
-import { ONE } from '../../../utils/constants';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { CoreContract, SetTokenFactoryContract, StandardTokenMockContract } from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { extractNewSetTokenAddressFromLogs, SetTokenCreated } from '@utils/contract_logs/core';
+import { ONE } from '@utils/constants';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreInternal.spec.ts
+++ b/test/core/extensions/coreInternal.spec.ts
@@ -1,22 +1,24 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreContract,
   SetTokenContract,
   SetTokenFactoryContract,
   TransferProxyContract,
   VaultContract
-} from '../../../utils/contracts';
-import { expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { STANDARD_NATURAL_UNIT } from '../../../utils/constants';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
+} from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { STANDARD_NATURAL_UNIT } from '@utils/constants';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreIssuance.spec.ts
+++ b/test/core/extensions/coreIssuance.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
@@ -5,8 +7,8 @@ import * as setProtocolUtils from 'set-protocol-utils';
 import { Address, Log } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreContract,
   RebalancingSetTokenContract,
@@ -16,11 +18,11 @@ import {
   StandardTokenMockContract,
   TransferProxyContract,
   VaultContract
-} from '../../../utils/contracts';
-import { ether } from '../../../utils/units';
-import { IssuanceComponentDeposited } from '../../../utils/contract_logs/core';
-import { assertTokenBalance, expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
+} from '@utils/contracts';
+import { ether } from '@utils/units';
+import { IssuanceComponentDeposited } from '@utils/contract_logs/core';
+import { assertTokenBalance, expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
 import {
   DEFAULT_GAS,
   DEPLOYED_TOKEN_QUANTITY,
@@ -28,10 +30,10 @@ import {
   DEFAULT_UNIT_SHARES,
   DEFAULT_REBALANCING_NATURAL_UNIT,
   ONE_DAY_IN_SECONDS
-} from '../../../utils/constants';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
-import { RebalancingTokenWrapper } from '../../../utils/RebalancingTokenWrapper';
+} from '@utils/constants';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
+import { RebalancingTokenWrapper } from '@utils/RebalancingTokenWrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreIssuanceOrder.spec.ts
+++ b/test/core/extensions/coreIssuanceOrder.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
@@ -11,8 +13,8 @@ import {
 } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreContract,
   SetTokenContract,
@@ -20,16 +22,16 @@ import {
   StandardTokenMockContract,
   TransferProxyContract,
   VaultContract
-} from '../../../utils/contracts';
-import { ether } from '../../../utils/units';
-import { assertTokenBalance, expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { DEFAULT_GAS, DEPLOYED_TOKEN_QUANTITY } from '../../../utils/constants';
-import { getExpectedFillLog, getExpectedCancelLog } from '../../../utils/contract_logs/coreIssuanceOrder';
-import { ExchangeWrapper } from '../../../utils/exchangeWrapper';
-import { generateOrdersDataWithIncorrectExchange } from '../../../utils/orders';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
+} from '@utils/contracts';
+import { ether } from '@utils/units';
+import { assertTokenBalance, expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { DEFAULT_GAS, DEPLOYED_TOKEN_QUANTITY } from '@utils/constants';
+import { getExpectedFillLog, getExpectedCancelLog } from '@utils/contract_logs/coreIssuanceOrder';
+import { ExchangeWrapper } from '@utils/exchangeWrapper';
+import { generateOrdersDataWithIncorrectExchange } from '@utils/orders';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
+++ b/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
@@ -5,8 +7,8 @@ import * as setProtocolUtils from 'set-protocol-utils';
 import { Address, Bytes } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreContract,
   SetTokenContract,
@@ -15,17 +17,17 @@ import {
   TakerWalletWrapperContract,
   TransferProxyContract,
   VaultContract
-} from '../../../utils/contracts';
-import { ether } from '../../../utils/units';
-import { assertTokenBalance } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { DEPLOYED_TOKEN_QUANTITY } from '../../../utils/constants';
+} from '@utils/contracts';
+import { ether } from '@utils/units';
+import { assertTokenBalance } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { DEPLOYED_TOKEN_QUANTITY } from '@utils/constants';
 import { SCENARIOS } from './coreIssuanceOrderScenarios';
-import { ExchangeWrapper } from '../../../utils/exchangeWrapper';
-import { generateFillOrderParameters, generateOrdersDataWithTakerOrders } from '../../../utils/orders';
-import { getExpectedFillLog } from '../../../utils/contract_logs/coreIssuanceOrder';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
+import { ExchangeWrapper } from '@utils/exchangeWrapper';
+import { generateFillOrderParameters, generateOrdersDataWithTakerOrders } from '@utils/orders';
+import { getExpectedFillLog } from '@utils/contract_logs/coreIssuanceOrder';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/extensions/coreIssuanceOrderScenarios.ts
+++ b/test/core/extensions/coreIssuanceOrderScenarios.ts
@@ -1,5 +1,7 @@
-import { DEPLOYED_TOKEN_QUANTITY, ZERO } from '../../../utils/constants';
-import { ether } from '../../../utils/units';
+require('module-alias/register');
+
+import { DEPLOYED_TOKEN_QUANTITY, ZERO } from '@utils/constants';
+import { ether } from '@utils/units';
 
 
 export const SCENARIOS = [

--- a/test/core/extensions/coreRebalanceAuction.spec.ts
+++ b/test/core/extensions/coreRebalanceAuction.spec.ts
@@ -1,11 +1,13 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import { Address } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../../utils/chaiSetup';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreMockContract,
   SetTokenContract,
@@ -14,17 +16,17 @@ import {
   SetTokenFactoryContract,
   TransferProxyContract,
   VaultContract,
-} from '../../../utils/contracts';
-import { ether } from '../../../utils/units';
+} from '@utils/contracts';
+import { ether } from '@utils/units';
 import {
   DEFAULT_GAS,
   ONE_DAY_IN_SECONDS,
-} from '../../../utils/constants';
-import { expectRevertError } from '../../../utils/tokenAssertions';
-import { Blockchain } from '../../../utils/blockchain';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../../utils/erc20Wrapper';
-import { RebalancingTokenWrapper } from '../../../utils/RebalancingTokenWrapper';
+} from '@utils/constants';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
+import { RebalancingTokenWrapper } from '@utils/RebalancingTokenWrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/lib/orderLibrary.spec.ts
+++ b/test/core/lib/orderLibrary.spec.ts
@@ -1,14 +1,16 @@
+require('module-alias/register');
+
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
 import { Address } from 'set-protocol-utils';
 
-import { OrderLibraryMockContract } from '../../../utils/contracts';
-import { CoreWrapper } from '../../../utils/coreWrapper';
-import { generateFillOrderParameters } from '../../../utils/orders';
-import { Blockchain } from '../../../utils/blockchain';
-import { ether } from '../../../utils/units';
-import { BigNumberSetup } from '../../../utils/bigNumberSetup';
-import ChaiSetup from '../../../utils/chaiSetup';
+import { OrderLibraryMockContract } from '@utils/contracts';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { generateFillOrderParameters } from '@utils/orders';
+import { Blockchain } from '@utils/blockchain';
+import { ether } from '@utils/units';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/rebalancingSetToken.spec.ts
+++ b/test/core/rebalancingSetToken.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
@@ -5,8 +7,8 @@ import * as setProtocolUtils from 'set-protocol-utils';
 import { Address } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreMockContract,
   SetTokenContract,
@@ -16,25 +18,25 @@ import {
   StandardTokenMockContract,
   TransferProxyContract,
   VaultContract,
-} from '../../utils/contracts';
-import { Blockchain } from '../../utils/blockchain';
-import { ether } from '../../utils/units';
+} from '@utils/contracts';
+import { Blockchain } from '@utils/blockchain';
+import { ether } from '@utils/units';
 import {
   DEFAULT_GAS,
   ONE_DAY_IN_SECONDS,
   DEFAULT_UNIT_SHARES,
   ZERO,
-} from '../../utils/constants';
+} from '@utils/constants';
 import {
   getExpectedTransferLog,
   getExpectedNewManagerAddedLog,
   getExpectedRebalanceProposedLog,
   getExpectedRebalanceStartedLog,
-} from '../../utils/contract_logs/rebalancingSetToken';
-import { expectRevertError, assertTokenBalance } from '../../utils/tokenAssertions';
-import { CoreWrapper } from '../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../utils/erc20Wrapper';
-import { RebalancingTokenWrapper } from '../../utils/RebalancingTokenWrapper';
+} from '@utils/contract_logs/rebalancingSetToken';
+import { expectRevertError, assertTokenBalance } from '@utils/tokenAssertions';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
+import { RebalancingTokenWrapper } from '@utils/RebalancingTokenWrapper';
 
 
 BigNumberSetup.configure();

--- a/test/core/rebalancingSetTokenFactory.spec.ts
+++ b/test/core/rebalancingSetTokenFactory.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
@@ -5,23 +7,23 @@ import * as setProtocolUtils from 'set-protocol-utils';
 import { Address, Bytes, Log } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   CoreContract,
   RebalancingSetTokenFactoryContract,
   SetTokenContract,
   SetTokenFactoryContract,
-} from '../../utils/contracts';
+} from '@utils/contracts';
 import {
   getRebalancingSetTokenAddressFromLogs,
-} from '../../utils/contract_logs/rebalancingSetTokenFactory';
-import { ether } from '../../utils/units';
-import { expectRevertError } from '../../utils/tokenAssertions';
-import { Blockchain } from '../../utils/blockchain';
-import { ZERO } from '../../utils/constants';
-import { CoreWrapper } from '../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../utils/erc20Wrapper';
+} from '@utils/contract_logs/rebalancingSetTokenFactory';
+import { ether } from '@utils/units';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { ZERO } from '@utils/constants';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/setToken.spec.ts
+++ b/test/core/setToken.spec.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
@@ -5,16 +7,16 @@ import * as setProtocolUtils from 'set-protocol-utils';
 import { Address } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
-import { StandardTokenMockContract, SetTokenFactoryContract, SetTokenContract } from '../../utils/contracts';
-import { ether } from '../../utils/units';
-import { assertTokenBalance, expectRevertError } from '../../utils/tokenAssertions';
-import { Blockchain } from '../../utils/blockchain';
-import { STANDARD_COMPONENT_UNIT, STANDARD_NATURAL_UNIT, ZERO } from '../../utils/constants';
-import { getExpectedTransferLog } from '../../utils/contract_logs/setToken';
-import { CoreWrapper } from '../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../utils/erc20Wrapper';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { StandardTokenMockContract, SetTokenFactoryContract, SetTokenContract } from '@utils/contracts';
+import { ether } from '@utils/units';
+import { assertTokenBalance, expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { STANDARD_COMPONENT_UNIT, STANDARD_NATURAL_UNIT, ZERO } from '@utils/constants';
+import { getExpectedTransferLog } from '@utils/contract_logs/setToken';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/setTokenFactory.spec.ts
+++ b/test/core/setTokenFactory.spec.ts
@@ -1,17 +1,19 @@
+require('module-alias/register');
+
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import * as setProtocolUtils from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 import { Address, Bytes } from 'set-protocol-utils';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
-import { StandardTokenMockContract, SetTokenFactoryContract } from '../../utils/contracts';
-import { expectRevertError } from '../../utils/tokenAssertions';
-import { Blockchain } from '../../utils/blockchain';
-import { ZERO } from '../../utils/constants';
-import { CoreWrapper } from '../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../utils/erc20Wrapper';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { StandardTokenMockContract, SetTokenFactoryContract } from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { ZERO } from '@utils/constants';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/transferProxy.spec.ts
+++ b/test/core/transferProxy.spec.ts
@@ -1,22 +1,24 @@
+require('module-alias/register');
+
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   InvalidReturnTokenMockContract,
   NoXferReturnTokenMockContract,
   StandardTokenMockContract,
   StandardTokenWithFeeMockContract,
   TransferProxyContract
-} from '../../utils/contracts';
-import { assertTokenBalance, expectRevertError } from '../../utils/tokenAssertions';
-import { Blockchain } from '../../utils/blockchain';
-import { DEPLOYED_TOKEN_QUANTITY, UNLIMITED_ALLOWANCE_IN_BASE_UNITS } from '../../utils/constants';
-import { CoreWrapper } from '../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../utils/erc20Wrapper';
+} from '@utils/contracts';
+import { assertTokenBalance, expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { DEPLOYED_TOKEN_QUANTITY, UNLIMITED_ALLOWANCE_IN_BASE_UNITS } from '@utils/constants';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/core/vault.spec.ts
+++ b/test/core/vault.spec.ts
@@ -1,23 +1,25 @@
+require('module-alias/register');
+
 import * as _ from 'lodash';
 import * as chai from 'chai';
 import * as setProtocolUtils from 'set-protocol-utils';
 import { Address } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   InvalidReturnTokenMockContract,
   NoXferReturnTokenMockContract,
   StandardTokenMockContract,
   StandardTokenWithFeeMockContract,
   VaultContract
-} from '../../utils/contracts';
-import { assertTokenBalance, expectRevertError } from '../../utils/tokenAssertions';
-import { Blockchain } from '../../utils/blockchain';
-import { DEPLOYED_TOKEN_QUANTITY, ZERO } from '../../utils/constants';
-import { CoreWrapper } from '../../utils/coreWrapper';
-import { ERC20Wrapper } from '../../utils/erc20Wrapper';
+} from '@utils/contracts';
+import { assertTokenBalance, expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { DEPLOYED_TOKEN_QUANTITY, ZERO } from '@utils/constants';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/lib/authorizable.spec.ts
+++ b/test/lib/authorizable.spec.ts
@@ -1,16 +1,18 @@
+require('module-alias/register');
+
 import * as ABIDecoder from 'abi-decoder';
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
 import { Address } from 'set-protocol-utils';
 import * as setProtocolUtils from 'set-protocol-utils';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
-import { Blockchain } from '../../utils/blockchain';
-import { AuthorizableContract } from '../../utils/contracts';
-import { getExpectedAddAuthorizedLog, getExpectedRemoveAuthorizedLog } from '../../utils/contract_logs/authorizable';
-import { expectRevertError } from '../../utils/tokenAssertions';
-import { CoreWrapper } from '../../utils/coreWrapper';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { Blockchain } from '@utils/blockchain';
+import { AuthorizableContract } from '@utils/contracts';
+import { getExpectedAddAuthorizedLog, getExpectedRemoveAuthorizedLog } from '@utils/contract_logs/authorizable';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { CoreWrapper } from '@utils/coreWrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/lib/bytes32.spec.ts
+++ b/test/lib/bytes32.spec.ts
@@ -1,11 +1,13 @@
+require('module-alias/register');
+
 import * as chai from 'chai';
 import { Bytes } from 'set-protocol-utils';
 import * as setProtocolUtils from 'set-protocol-utils';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
-import { Bytes32MockContract } from '../../utils/contracts';
-import { LibraryMockWrapper } from '../../utils/libraryMockWrapper';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { Bytes32MockContract } from '@utils/contracts';
+import { LibraryMockWrapper } from '@utils/libraryMockWrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/lib/commonMath.spec.ts
+++ b/test/lib/commonMath.spec.ts
@@ -1,11 +1,13 @@
+require('module-alias/register');
+
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
-import { CommonMathMockContract } from '../../utils/contracts';
-import { LibraryMockWrapper } from '../../utils/libraryMockWrapper';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import { CommonMathMockContract } from '@utils/contracts';
+import { LibraryMockWrapper } from '@utils/libraryMockWrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/lib/erc20Wrapper.spec.ts
+++ b/test/lib/erc20Wrapper.spec.ts
@@ -1,19 +1,21 @@
+require('module-alias/register');
+
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
 import { Address } from 'set-protocol-utils';
 
-import ChaiSetup from '../../utils/chaiSetup';
-import { BigNumberSetup } from '../../utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
   InvalidReturnTokenMockContract,
   ERC20WrapperMockContract,
   StandardTokenMockContract
-} from '../../utils/contracts';
-import { ether } from '../../utils/units';
-import { expectRevertError } from '../../utils/tokenAssertions';
-import { UNLIMITED_ALLOWANCE_IN_BASE_UNITS, ZERO } from '../../utils/constants';
-import { LibraryMockWrapper } from '../../utils/libraryMockWrapper';
-import { ERC20Wrapper } from '../../utils/erc20Wrapper';
+} from '@utils/contracts';
+import { ether } from '@utils/units';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { UNLIMITED_ALLOWANCE_IN_BASE_UNITS, ZERO } from '@utils/constants';
+import { LibraryMockWrapper } from '@utils/libraryMockWrapper';
+import { ERC20Wrapper } from '@utils/erc20Wrapper';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -6,6 +6,10 @@
     "lib": ["dom", "es2015", "es2016", "es2017"],
     "module": "commonjs",
     "baseUrl": ".",
+    "moduleResolution": "node",
+    "paths": {
+        "@utils/*": [ "utils/*" ]
+    },
     "rootDir": ".",
     "target": "es5",
     "types": [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,10 @@
     "lib": ["dom", "es2015", "es2016", "es2017"],
     "module": "commonjs",
     "baseUrl": ".",
+    "moduleResolution": "node",
+    "paths": {
+        "@utils/*": [ "utils/*" ]
+    },
     "rootDir": ".",
     "target": "es5",
     "allowJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3867,6 +3867,10 @@ mocha@^4.0.1, mocha@^4.1.0:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
+module-alias@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.1.0.tgz#c36d4fd15f7f9d7112f62fa015385e7b65a286c1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
This PR shows how we can use Module Path Aliases to improve our developer experience when importing files.

Notes
- Since we don't have a top-level file in our tests, we need to use this line on top of each file `require('module-alias/register');`
- The path aliases need to be defined in 3 places: `tsconfig.json`, `tsconfig.path.json`, and `package.json` (which points to transpiled).


Learn more at this article [here](https://medium.com/@caludio/how-to-use-module-path-aliases-in-visual-studio-typescript-and-javascript-e7851df8eeaa).