### PR TITLE
Only transfer maker token specified by signed issuance order

### DIFF
--- a/contracts/core/lib/ExchangeHandler.sol
+++ b/contracts/core/lib/ExchangeHandler.sol
@@ -36,9 +36,8 @@ library ExchangeHandler {
     struct ExchangeHeader {
         uint8 exchange;
         uint8 orderCount;
-        address makerTokenAddress;
         uint256 makerTokenAmount;
-        uint256 totalOrdersLength;
+        uint256 orderDataBytesLength;
     }
 
     // ============ Internal Functions ============
@@ -64,9 +63,8 @@ library ExchangeHandler {
         assembly {
             mstore(header,          mload(headerDataStart))            // exchange
             mstore(add(header, 32), mload(add(headerDataStart, 32)))   // orderCount
-            mstore(add(header, 64), mload(add(headerDataStart, 64)))   // makerTokenAddress
-            mstore(add(header, 96), mload(add(headerDataStart, 96)))   // makerTokenAmount
-            mstore(add(header, 128), mload(add(headerDataStart, 128))) // totalOrdersLength
+            mstore(add(header, 64), mload(add(headerDataStart, 64)))   // makerTokenAmount
+            mstore(add(header, 96), mload(add(headerDataStart, 96)))   // orderDataBytesLength
         }
 
         return header;

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
     "module-alias": "^2.1.0",
-    "set-protocol-utils": "^0.3.32",
+    "set-protocol-utils": "^0.3.33",
     "sol-trace-set": "^0.0.1",
     "solium": "^1.1.7",
     "tiny-promisify": "^1.0.0",

--- a/test/core/extensions/coreIssuanceOrder.spec.ts
+++ b/test/core/extensions/coreIssuanceOrder.spec.ts
@@ -232,7 +232,6 @@ contract('CoreIssuanceOrder', accounts => {
       subjectVSignature = new BigNumber(signature.v);
       subjectSigBytes = [signature.r, signature.s];
       subjectExchangeOrdersData = setUtils.generateSerializedOrders(
-        makerToken.address,
         makerTokenAmountToUseAcrossLiqudityOrders || zeroExOrderTakerAssetAmount,
         [zeroExOrder, takerWalletOrder]
       );

--- a/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
+++ b/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
@@ -207,7 +207,6 @@ contract('CoreIssuanceOrder::Scenarios', accounts => {
           });
 
           subjectExchangeOrdersData = generateOrdersDataWithTakerOrders(
-            makerToken.address,
             takerComponents,
             takerAmountsToTransfer,
           );

--- a/utils/orders.ts
+++ b/utils/orders.ts
@@ -8,7 +8,6 @@ import {
   IssuanceOrder
 }  from 'set-protocol-utils';
 
-import { ether } from './units';
 
 const setUtils = new SetProtocolUtils(web3);
 
@@ -74,28 +73,7 @@ export async function generateFillOrderParameters(
   };
 }
 
-export function generateOrdersDataForOrderCount(
-  orderCount: number,
-  makerTokenAddress: Address,
-  makerTokenAmounts: number[],
-): Bytes {
-  const exchangeOrderDatum: Buffer[] = [];
-  _.times(orderCount, index => {
-    const exchange = _.sample(SetProtocolUtils.EXCHANGES);
-    exchangeOrderDatum.push(SetProtocolUtils.paddedBufferForPrimitive(exchange));
-    exchangeOrderDatum.push(SetProtocolUtils.paddedBufferForPrimitive(makerTokenAddress));
-    exchangeOrderDatum.push(SetProtocolUtils.paddedBufferForBigNumber(ether(makerTokenAmounts[index])));
-
-    const totalOrdersLength = _.random(200, 250); // Fake order data
-    exchangeOrderDatum.push(SetProtocolUtils.paddedBufferForPrimitive(totalOrdersLength));
-    exchangeOrderDatum.push(randomBufferOfLength(totalOrdersLength));
-  });
-
-  return ethUtil.bufferToHex(Buffer.concat(exchangeOrderDatum));
-}
-
 export function generateOrdersDataWithTakerOrders(
-  makerTokenAddress: Address,
   takerTokenAddresses: Address[],
   takerTokenAmounts: BigNumber[],
 ): Bytes {
@@ -103,7 +81,6 @@ export function generateOrdersDataWithTakerOrders(
   const exchangeOrderDatum: Buffer[] = [
     SetProtocolUtils.paddedBufferForPrimitive(SetProtocolUtils.EXCHANGES.TAKER_WALLET),
     SetProtocolUtils.paddedBufferForPrimitive(takerTokenAddresses.length), // Include the number of orders
-    SetProtocolUtils.paddedBufferForPrimitive(makerTokenAddress),
     SetProtocolUtils.paddedBufferForPrimitive(0), // Taker wallet orders do not take any maker token to execute
   ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4933,9 +4933,9 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-set-protocol-utils@^0.3.32:
-  version "0.3.32"
-  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-0.3.32.tgz#91150dd15d0ec2bc51cfc305d248d1d52db7d588"
+set-protocol-utils@^0.3.33:
+  version "0.3.33"
+  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-0.3.33.tgz#0ad41e32ec1ee5b81a7d2e8262ddfb32b55c19fb"
   dependencies:
     "@0xproject/base-contract" "^1.0.4"
     "@0xproject/order-utils" "^1.0.1-rc.2"


### PR DESCRIPTION
We always transfer the maker token specified in the signed issuance order instead of one passed in through the orders data exchange header which can be arbitrary.