### PR TITLE
Exchange wrapper optimizations, minimize unnecessary transfers/approvals

### DIFF
--- a/contracts/core/extensions/CoreIssuanceOrder.sol
+++ b/contracts/core/extensions/CoreIssuanceOrder.sol
@@ -292,6 +292,8 @@ contract CoreIssuanceOrder is
             (componentFillTokens, componentFillAmounts) = IExchangeWrapper(exchange).exchange(
                 _makerAddress,
                 msg.sender,
+                _makerTokenAddress,
+                header.makerTokenAmount,
                 header.orderCount,
                 bodyData
             );

--- a/contracts/core/interfaces/IExchangeWrapper.sol
+++ b/contracts/core/interfaces/IExchangeWrapper.sol
@@ -32,13 +32,18 @@ interface IExchangeWrapper {
      *
      * @param  _maker                Issuance order maker
      * @param  _taker                Issuance order taker
+     * @param  _makerToken           Address of maker token used in exchange orders
+     * @param  _makerAssetAmount     Amount of issuance order maker token to use on this exchange
      * @param  _orderCount           Expected number of orders to execute
      * @param  _orderData            Arbitrary bytes data for any information to pass to the exchange
-     * @return  address[], uint256[] The taker token addresses and the associated quantities       
+     * @return  address[]            The addresses of required components 
+     * @return  uint256[]            The quantities of required components retrieved by the wrapper
      */
     function exchange(
         address _maker,
         address _taker,
+        address _makerToken,
+        uint256 _makerAssetAmount,
         uint256 _orderCount,
         bytes _orderData
     )

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
     "module-alias": "^2.1.0",
-    "set-protocol-utils": "^0.3.33",
+    "set-protocol-utils": "^0.3.37",
     "sol-trace-set": "^0.0.1",
     "solium": "^1.1.7",
     "tiny-promisify": "^1.0.0",

--- a/test/core/exchange-wrappers/kyberNetworkWrapper.spec.ts
+++ b/test/core/exchange-wrappers/kyberNetworkWrapper.spec.ts
@@ -1,7 +1,6 @@
 require('module-alias/register');
 
 import * as chai from 'chai';
-import * as ethUtil from 'ethereumjs-util';
 import * as setProtocolUtils from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 import { Address, Bytes, KyberTrade } from 'set-protocol-utils';
@@ -23,8 +22,7 @@ import { expectRevertError } from '@utils/tokenAssertions';
 BigNumberSetup.configure();
 ChaiSetup.configure();
 const { expect } = chai;
-const { SetProtocolTestUtils: SetTestUtils, SetProtocolUtils: SetUtils } = setProtocolUtils;
-const setUtils = new SetUtils(web3);
+const { SetProtocolTestUtils: SetTestUtils } = setProtocolUtils;
 const blockchain = new Blockchain(web3);
 
 
@@ -64,6 +62,8 @@ contract('KyberNetworkWrapper', accounts => {
     let subjectCaller: Address;
     let subjectMaker: Address;
     let subjectTaker: Address;
+    let subjectMakerTokenAddress: Address;
+    let subjectMakerTokenAmount: BigNumber;
     let subjectTradesCount: BigNumber;
     let subjectTradesData: Bytes;
 
@@ -107,14 +107,18 @@ contract('KyberNetworkWrapper', accounts => {
       subjectCaller = authorizedAddress;
       subjectMaker = issuanceOrderMakerAccount;
       subjectTaker = takerAccount;
+      subjectMakerTokenAddress = sourceToken.address;
+      subjectMakerTokenAmount = sourceTokenQuantity;
       subjectTradesCount = new BigNumber(1);
-      subjectTradesData = ethUtil.bufferToHex(setUtils.kyberTradeToBuffer(kyberTrade));
+      subjectTradesData = SetTestUtils.kyberTradeToBytes(kyberTrade);
     });
 
     async function subject(): Promise<string> {
       return kyberNetworkWrapper.exchange.sendTransactionAsync(
         subjectMaker,
         subjectTaker,
+        subjectMakerTokenAddress,
+        subjectMakerTokenAmount,
         subjectTradesCount,
         subjectTradesData,
         { from: subjectCaller, gas: DEFAULT_GAS },

--- a/test/core/exchange-wrappers/lib/zeroExOrderDataHandlerMock.spec.ts
+++ b/test/core/exchange-wrappers/lib/zeroExOrderDataHandlerMock.spec.ts
@@ -58,7 +58,7 @@ contract('ZeroExOrderDataHandlerMock', accounts => {
     await blockchain.saveSnapshotAsync();
 
     zeroExExchangeWrapper = await libraryMockWrapper.deployZeroExOrderDataHandlerLibraryAsync();
-    zeroExOrder = SetUtils.generateZeroExOrder(
+    zeroExOrder = SetTestUtils.generateZeroExOrder(
       senderAddress || senderAccount,
       makerAddress || ownerAccount,
       takerAddress || takerAccount,
@@ -71,7 +71,7 @@ contract('ZeroExOrderDataHandlerMock', accounts => {
       salt || SetUtils.generateSalt(),
       SetTestUtils.ZERO_EX_EXCHANGE_ADDRESS,
       feeRecipientAddress,
-      expirationTimeSeconds || SetUtils.generateTimestamp(10),
+      expirationTimeSeconds || SetTestUtils.generateTimestamp(10),
     );
 
     makerAssetData = assetDataUtils.encodeERC20AssetData(makerTokenAddress);
@@ -80,7 +80,7 @@ contract('ZeroExOrderDataHandlerMock', accounts => {
     signature = '0x0012034334393842';
     fillAmount = ether(1);
 
-    zeroExWrapperOrderData = SetUtils.generateZeroExExchangeWrapperOrder(zeroExOrder, signature, fillAmount);
+    zeroExWrapperOrderData = SetTestUtils.generateZeroExExchangeWrapperOrder(zeroExOrder, signature, fillAmount);
   });
 
   afterEach(async () => {
@@ -113,7 +113,7 @@ contract('ZeroExOrderDataHandlerMock', accounts => {
     it('correctly parses the zeroEx order length', async () => {
       const [, parsedOrderLength] = await subject();
 
-      const expectedLength = SetUtils.numBytesFromBuffer(SetUtils.zeroExOrderToBuffer(zeroExOrder));
+      const expectedLength = SetUtils.numBytesFromBuffer(SetTestUtils.zeroExOrderToBuffer(zeroExOrder));
       expect(parsedOrderLength).to.bignumber.equal(expectedLength);
     });
 
@@ -178,7 +178,7 @@ contract('ZeroExOrderDataHandlerMock', accounts => {
       takerFee = ether(1);
       makerAssetAmount = ether(1);
       takerAssetAmount = ether(1);
-      expirationTimeSeconds = SetUtils.generateTimestamp(10);
+      expirationTimeSeconds = SetTestUtils.generateTimestamp(10);
       salt = SetUtils.generateSalt();
     });
 

--- a/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
+++ b/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
@@ -2,6 +2,7 @@ require('module-alias/register');
 
 import * as _ from 'lodash';
 import * as chai from 'chai';
+import * as setProtocolUtils from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 import { Address, Bytes } from 'set-protocol-utils';
 
@@ -26,8 +27,10 @@ import { expectRevertError } from '@utils/tokenAssertions';
 
 BigNumberSetup.configure();
 ChaiSetup.configure();
+const { SetProtocolUtils: SetUtils } = setProtocolUtils;
 const { expect } = chai;
 const blockchain = new Blockchain(web3);
+const { ZERO } = SetUtils.CONSTANTS;
 
 
 contract('TakerWalletWrapper', accounts => {
@@ -69,6 +72,10 @@ contract('TakerWalletWrapper', accounts => {
 
   describe('#exchange', async () => {
     let subjectCaller: Address;
+    let subjectMakerAccount: Address;
+    let subjectTakerAccount: Address;
+    let subjectMakerTokenAddress: Address;
+    let subjectMakerTokenAmount: BigNumber;
     let subjectOrderCount: BigNumber;
     let subjectTakerOrdersData: Bytes;
 
@@ -81,14 +88,20 @@ contract('TakerWalletWrapper', accounts => {
       const transferAmounts = _.map(components, token => transferAmount);
 
       subjectCaller = authorizedAddress;
+      subjectMakerAccount = makerAccount;
+      subjectTakerAccount = takerAccount;
+      subjectMakerTokenAddress = componentToken.address;
+      subjectMakerTokenAmount = ZERO;
       subjectOrderCount = new BigNumber(componentAddresses.length);
       subjectTakerOrdersData = generateTakerWalletOrders(componentAddresses, transferAmounts);
     });
 
     async function subject(): Promise<string> {
       return takerWalletWrapper.exchange.sendTransactionAsync(
-        makerAccount,
-        takerAccount,
+        subjectMakerAccount,
+        subjectTakerAccount,
+        subjectMakerTokenAddress,
+        subjectMakerTokenAmount,
         subjectOrderCount,
         subjectTakerOrdersData,
         { from: subjectCaller, gas: DEFAULT_GAS },

--- a/test/core/rebalancingSetTokenFactory.spec.ts
+++ b/test/core/rebalancingSetTokenFactory.spec.ts
@@ -111,7 +111,7 @@ contract('RebalancingSetTokenFactory', accounts => {
       const asciiSubjectSymbol = 'REBAL';
       subjectName = SetUtils.stringToBytes(asciiSubjectName);
       subjectSymbol = SetUtils.stringToBytes(asciiSubjectSymbol);
-      subjectCallData = SetUtils.bufferArrayToHex([
+      subjectCallData = SetTestUtils.bufferArrayToHex([
         SetUtils.paddedBufferForPrimitive(managerAddress),
         SetUtils.paddedBufferForBigNumber(proposalPeriod),
         SetUtils.paddedBufferForBigNumber(rebalanceInterval),
@@ -221,7 +221,7 @@ contract('RebalancingSetTokenFactory', accounts => {
       const asciiSubjectSymbol = 'REBAL';
       subjectName = SetUtils.stringToBytes(asciiSubjectName);
       subjectSymbol = SetUtils.stringToBytes(asciiSubjectSymbol);
-      subjectCallData = SetUtils.bufferArrayToHex([
+      subjectCallData = SetTestUtils.bufferArrayToHex([
         SetUtils.paddedBufferForPrimitive(managerAddress),
         SetUtils.paddedBufferForBigNumber(proposalPeriod),
         SetUtils.paddedBufferForBigNumber(rebalanceInterval),

--- a/utils/RebalancingTokenWrapper.ts
+++ b/utils/RebalancingTokenWrapper.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { SetProtocolUtils, Address } from 'set-protocol-utils';
+import { Address, SetProtocolUtils, SetProtocolTestUtils } from 'set-protocol-utils';
 
 import {
   CoreContract,
@@ -107,7 +107,7 @@ export class RebalancingTokenWrapper {
     // Generate defualt rebalancingSetToken params
     const initialUnitShares = DEFAULT_UNIT_SHARES;
     const rebalanceInterval = ONE_DAY_IN_SECONDS;
-    const callData = SetProtocolUtils.bufferArrayToHex([
+    const callData = SetProtocolTestUtils.bufferArrayToHex([
       SetProtocolUtils.paddedBufferForPrimitive(manager),
       SetProtocolUtils.paddedBufferForBigNumber(proposalPeriod),
       SetProtocolUtils.paddedBufferForBigNumber(rebalanceInterval),

--- a/utils/orders.ts
+++ b/utils/orders.ts
@@ -3,6 +3,7 @@ import * as ethUtil from 'ethereumjs-util';
 import { BigNumber } from 'bignumber.js';
 import {
   SetProtocolUtils,
+  SetProtocolTestUtils,
   Address,
   Bytes,
   IssuanceOrder
@@ -35,7 +36,7 @@ export async function generateFillOrderParameters(
     relayerToken,
     quantity,
     makerTokenAmount,
-    expiration: SetProtocolUtils.generateTimestamp(timeToExpiration),
+    expiration: SetProtocolTestUtils.generateTimestamp(timeToExpiration),
     makerRelayerFee,
     takerRelayerFee,
     salt: SetProtocolUtils.generateSalt(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4933,9 +4933,9 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-set-protocol-utils@^0.3.33:
-  version "0.3.33"
-  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-0.3.33.tgz#0ad41e32ec1ee5b81a7d2e8262ddfb32b55c19fb"
+set-protocol-utils@^0.3.37:
+  version "0.3.37"
+  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-0.3.37.tgz#4632ff3708dc0c9792a4c63765ac6518c709b790"
   dependencies:
     "@0xproject/base-contract" "^1.0.4"
     "@0xproject/order-utils" "^1.0.1-rc.2"


### PR DESCRIPTION
Passing in additional parameters into the wrappers. This will require a redeploy of contracts for it to work on TestNet since the wrappers and parameters that core pass are no longer sufficient.

- Kyber wrapper does one approval for the source token
- Kyber wrapper transfers source token 'change' to the issuance order maker once. This was actually a critical bug
- ZeroEx wrapper does one approval for the issuance order taker token