### PR TITLE
Remove authorizable from unnecessary contracts

### DIFF
--- a/contracts/core/exchange-wrappers/TakerWalletWrapper.sol
+++ b/contracts/core/exchange-wrappers/TakerWalletWrapper.sol
@@ -18,7 +18,6 @@ pragma solidity 0.4.24;
 pragma experimental "ABIEncoderV2";
 
 import { SafeMath } from "zeppelin-solidity/contracts/math/SafeMath.sol";
-import { Authorizable } from "../../lib/Authorizable.sol";
 import { ERC20Wrapper } from "../../lib/ERC20Wrapper.sol";
 import { ITransferProxy } from "../interfaces/ITransferProxy.sol";
 import { LibBytes } from "../../external/0x/LibBytes.sol";
@@ -30,14 +29,13 @@ import { LibBytes } from "../../external/0x/LibBytes.sol";
  *
  * The TakerWalletWrapper contract wrapper to transfer tokens directly from order taker
  */
-contract TakerWalletWrapper is
-    Authorizable
-{
+contract TakerWalletWrapper {
     using LibBytes for bytes;
     using SafeMath for uint256;
 
     /* ============ State Variables ============ */
 
+    address public core;
     address public transferProxy;
 
     /* ============ Constructor ============ */
@@ -45,15 +43,16 @@ contract TakerWalletWrapper is
     /**
      * Sets the transferProxy address for the contract
      *
-     * @param  _transferProxy    Address of current transferProxy
+     * @param  _core            Authorized Core contract that sends Taker transfers orders
+     * @param _transferProxy    Address of current transferProxy
      */
     constructor(
+        address _core,
         address _transferProxy
     )
         public
-        Authorizable(2592000) // about 4 weeks
     {
-        // Set transferProxy address
+        core = _core;
         transferProxy = _transferProxy;
     }
 
@@ -81,9 +80,10 @@ contract TakerWalletWrapper is
         bytes _transfersData
     )
         public
-        onlyAuthorized
         returns(address[], uint256[])
     {
+        require(msg.sender == core, "ONLY_CORE_CAN_EXCHANGE_TAKER");
+        
         address[] memory takerTokens = new address[](_orderCount);
         uint256[] memory takerTokenAmounts = new uint256[](_orderCount);
 

--- a/contracts/core/exchange-wrappers/ZeroExExchangeWrapper.sol
+++ b/contracts/core/exchange-wrappers/ZeroExExchangeWrapper.sol
@@ -54,6 +54,7 @@ contract ZeroExExchangeWrapper {
      * @param _core               Authorized Core contract that sends 0x orders
      * @param _zeroExExchange     0x Exchange contract for filling orders
      * @param _zeroExProxy        0x Proxy contract for transferring
+     * @param _zeroExToken        ZRX token contract addressed used for 0x relayer fees
      * @param _setTransferProxy   Set Protocol transfer proxy contract
      */
     constructor(

--- a/contracts/core/exchange-wrappers/ZeroExExchangeWrapper.sol
+++ b/contracts/core/exchange-wrappers/ZeroExExchangeWrapper.sol
@@ -17,7 +17,6 @@
 pragma solidity 0.4.24;
 pragma experimental "ABIEncoderV2";
 
-import { Authorizable } from "../../lib/Authorizable.sol";
 import { SafeMath } from "zeppelin-solidity/contracts/math/SafeMath.sol";
 import { CommonMath } from "../../lib/CommonMath.sol";
 import { ERC20Wrapper as ERC20 } from "../../lib/ERC20Wrapper.sol";
@@ -35,14 +34,13 @@ import { ZeroExOrderDataHandler as OrderHandler } from "./lib/ZeroExOrderDataHan
  *
  * The ZeroExExchangeWrapper contract wrapper to interface with 0x V2
  */
-contract ZeroExExchangeWrapper is
-    Authorizable
-{
+contract ZeroExExchangeWrapper {
     using LibBytes for bytes;
     using SafeMath for uint256;
 
     /* ============ State Variables ============ */
 
+    address public core;
     address public zeroExExchange;
     address public zeroExProxy;
     address public zeroExToken;
@@ -53,19 +51,21 @@ contract ZeroExExchangeWrapper is
     /**
      * Initialize exchange wrapper with required addresses to facilitate 0x orders
      *
-     * @param  _zeroExExchange     0x Exchange contract for filling orders
-     * @param  _zeroExProxy        0x Proxy contract for transferring
-     * @param  _setTransferProxy   Set Protocol transfer proxy contract
+     * @param _core               Authorized Core contract that sends 0x orders
+     * @param _zeroExExchange     0x Exchange contract for filling orders
+     * @param _zeroExProxy        0x Proxy contract for transferring
+     * @param _setTransferProxy   Set Protocol transfer proxy contract
      */
     constructor(
+        address _core,
         address _zeroExExchange,
         address _zeroExProxy,
         address _zeroExToken,
         address _setTransferProxy
     )
         public
-        Authorizable(2592000) // about 4 weeks
     {
+        core = _core;
         zeroExExchange = _zeroExExchange;
         zeroExProxy = _zeroExProxy;
         zeroExToken = _zeroExToken;
@@ -105,9 +105,10 @@ contract ZeroExExchangeWrapper is
         bytes _ordersData
     )
         external
-        onlyAuthorized
         returns (address[], uint256[])
     {
+        require(msg.sender == core, "ONLY_CORE_CAN_EXCHANGE_0X");
+
         // Ensure the taker token is allowed to be transferred by ZeroEx Proxy
         ERC20.ensureAllowance(
             _makerToken,

--- a/migrations/2_core.js
+++ b/migrations/2_core.js
@@ -86,12 +86,13 @@ async function deployCoreContracts(deployer, network) {
   }
 
   // Taker Wallet Wrapper
-  await deployer.deploy(TakerWalletWrapper, TransferProxy.address);
+  await deployer.deploy(TakerWalletWrapper, Core.address, TransferProxy.address);
 
   // Kyber Wrapper
   if (kyberNetworkProxyAddress) {
     await deployer.deploy(
       KyberNetworkWrapper,
+      Core.address,
       kyberNetworkProxyAddress,
       TransferProxy.address
     );
@@ -101,6 +102,7 @@ async function deployCoreContracts(deployer, network) {
   if (zeroExExchangeAddress && zeroExERC20ProxyAddress) {
     await deployer.deploy(
       ZeroExExchangeWrapper,
+      Core.address,
       zeroExExchangeAddress,
       zeroExERC20ProxyAddress,
       TransferProxy.address
@@ -133,14 +135,11 @@ async function addAuthorizations(deployer, network) {
   if (network === 'kovan' || network === 'development') {
     await core.registerExchange(EXCHANGES.ZERO_EX, ZeroExExchangeWrapper.address);
     const zeroExExchangeWrapper = await ZeroExExchangeWrapper.deployed();
-    await zeroExExchangeWrapper.addAuthorizedAddress(Core.address);
   };
 
   await core.registerExchange(EXCHANGES.KYBER, KyberNetworkWrapper.address);
   const kyberNetworkWrapper = await KyberNetworkWrapper.deployed();  
-  await kyberNetworkWrapper.addAuthorizedAddress(Core.address);
 
   await core.registerExchange(EXCHANGES.TAKER_WALLET, TakerWalletWrapper.address);
   const takerWalletWrapper = await TakerWalletWrapper.deployed();
-  await takerWalletWrapper.addAuthorizedAddress(Core.address);
 };

--- a/test/core/exchange-wrappers/kyberNetworkWrapper.spec.ts
+++ b/test/core/exchange-wrappers/kyberNetworkWrapper.spec.ts
@@ -194,7 +194,7 @@ contract('KyberNetworkWrapper', accounts => {
       expect(newBalance).to.be.bignumber.equal(expectedNewAllowance);
     });
 
-    describe('when the caller is not authorized', async () => {
+    describe('when the caller is not the initialized core address', async () => {
       beforeEach(async () => {
         subjectCaller = unauthorizedAddress;
       });

--- a/test/core/exchange-wrappers/kyberNetworkWrapper.spec.ts
+++ b/test/core/exchange-wrappers/kyberNetworkWrapper.spec.ts
@@ -7,11 +7,7 @@ import { Address, Bytes, KyberTrade } from 'set-protocol-utils';
 
 import ChaiSetup from '@utils/chaiSetup';
 import { BigNumberSetup } from '@utils/bigNumberSetup';
-import {
-  StandardTokenMockContract,
-  KyberNetworkWrapperContract,
-  TransferProxyContract
-} from '@utils/contracts';
+import { StandardTokenMockContract, KyberNetworkWrapperContract, TransferProxyContract } from '@utils/contracts';
 import { ether } from '@utils/units';
 import { CoreWrapper } from '@utils/coreWrapper';
 import { ERC20Wrapper } from '@utils/erc20Wrapper';
@@ -30,7 +26,7 @@ const blockchain = new Blockchain(web3);
 contract('KyberNetworkWrapper', accounts => {
   const [
     deployerAccount,
-    authorizedAddress,
+    deployedCoreAddress,
     unauthorizedAddress,
     issuanceOrderMakerAccount,
     takerAccount,
@@ -47,12 +43,11 @@ contract('KyberNetworkWrapper', accounts => {
     await blockchain.saveSnapshotAsync();
 
     transferProxy = await coreWrapper.deployTransferProxyAsync();
-
     kyberNetworkWrapper = await exchangeWrapper.deployKyberNetworkWrapper(
+      deployedCoreAddress,
       SetTestUtils.KYBER_NETWORK_PROXY_ADDRESS,
       transferProxy
     );
-    await coreWrapper.addAuthorizationAsync(kyberNetworkWrapper, authorizedAddress);
   });
 
   afterEach(async () => {
@@ -72,7 +67,7 @@ contract('KyberNetworkWrapper', accounts => {
       makerToken = erc20Wrapper.kyberReserveToken(SetTestUtils.KYBER_RESERVE_SOURCE_TOKEN_ADDRESS);
       componentToken = erc20Wrapper.kyberReserveToken(SetTestUtils.KYBER_RESERVE_DESTINATION_TOKEN_ADDRESS);
 
-      subjectCaller = authorizedAddress;
+      subjectCaller = deployedCoreAddress;
       subjectMakerToken = makerToken.address;
       subjectComponentToken = componentToken.address;
       subjectQuantity = ether(5);
@@ -146,7 +141,7 @@ contract('KyberNetworkWrapper', accounts => {
         maxDestinationQuantity: maxDestinationQuantity,
       } as KyberTrade;
 
-      subjectCaller = authorizedAddress;
+      subjectCaller = deployedCoreAddress;
       subjectMaker = issuanceOrderMakerAccount;
       subjectTaker = takerAccount;
       subjectMakerTokenAddress = sourceToken.address;

--- a/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
+++ b/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
@@ -58,8 +58,7 @@ contract('TakerWalletWrapper', accounts => {
 
     transferProxy = await coreWrapper.deployTransferProxyAsync();
 
-    takerWalletWrapper = await exchangeWrapper.deployTakerWalletExchangeWrapper(transferProxy);
-    await coreWrapper.addAuthorizationAsync(takerWalletWrapper, authorizedAddress);
+    takerWalletWrapper = await exchangeWrapper.deployTakerWalletExchangeWrapper(authorizedAddress, transferProxy);
     await coreWrapper.addAuthorizationAsync(transferProxy, takerWalletWrapper.address);
 
     components = await erc20Wrapper.deployTokensAsync(componentCount, takerAccount);

--- a/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
+++ b/test/core/exchange-wrappers/takerWalletWrapper.spec.ts
@@ -139,7 +139,7 @@ contract('TakerWalletWrapper', accounts => {
       expect(newBalance).to.be.bignumber.equal(expectedNewAllowance);
     });
 
-    describe('when the caller is not authorized', async () => {
+    describe('when the caller is not the deployed core address', async () => {
       beforeEach(async () => {
         subjectCaller = unauthorizedAddress;
       });

--- a/test/core/exchange-wrappers/zeroExExchangeWrapper.spec.ts
+++ b/test/core/exchange-wrappers/zeroExExchangeWrapper.spec.ts
@@ -63,12 +63,12 @@ contract('ZeroExExchangeWrapper', accounts => {
     transferProxy = await coreWrapper.deployTransferProxyAsync();
 
     zeroExExchangeWrapper = await exchangeWrapper.deployZeroExExchangeWrapper(
+      deployerAccount,
       SetTestUtils.ZERO_EX_EXCHANGE_ADDRESS,
       SetTestUtils.ZERO_EX_ERC20_PROXY_ADDRESS,
       SetTestUtils.ZERO_EX_TOKEN_ADDRESS,
       transferProxy,
     );
-    await coreWrapper.addAuthorizationAsync(zeroExExchangeWrapper, deployerAccount);
 
     // ZRX token is already deployed to zrxTokenOwnerAccount via the test snapshot
     zrxToken = erc20Wrapper.zrxToken();

--- a/test/core/extensions/coreIssuanceOrder.spec.ts
+++ b/test/core/extensions/coreIssuanceOrder.spec.ts
@@ -127,18 +127,18 @@ contract('CoreIssuanceOrder', accounts => {
     let kyberConversionRatePower: BigNumber;
 
     beforeEach(async () => {
-      await exchangeWrapper.deployAndAuthorizeTakerWalletExchangeWrapper(transferProxy, core);
+      await exchangeWrapper.deployAndAuthorizeTakerWalletExchangeWrapper(core, transferProxy);
       await exchangeWrapper.deployAndAuthorizeZeroExExchangeWrapper(
+        core,
         SetTestUtils.ZERO_EX_EXCHANGE_ADDRESS,
         SetTestUtils.ZERO_EX_ERC20_PROXY_ADDRESS,
         SetTestUtils.ZERO_EX_TOKEN_ADDRESS,
-        transferProxy,
-        core
+        transferProxy
       );
       await exchangeWrapper.deployAndAuthorizeKyberNetworkWrapper(
+        core,
         SetTestUtils.KYBER_NETWORK_PROXY_ADDRESS,
-        transferProxy,
-        core
+        transferProxy
       );
 
       const firstComponent = await erc20Wrapper.deployTokenAsync(issuanceOrderTaker);

--- a/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
+++ b/test/core/extensions/coreIssuanceOrderScenarios.spec.ts
@@ -73,8 +73,7 @@ contract('CoreIssuanceOrder::Scenarios', accounts => {
     setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync(core.address);
     await coreWrapper.setDefaultStateAndAuthorizationsAsync(core, vault, transferProxy, setTokenFactory);
 
-    takerWalletWrapper = await exchangeWrapper.deployTakerWalletExchangeWrapper(transferProxy);
-    await coreWrapper.addAuthorizationAsync(takerWalletWrapper, core.address);
+    takerWalletWrapper = await exchangeWrapper.deployTakerWalletExchangeWrapper(core.address, transferProxy);
     await coreWrapper.addAuthorizationAsync(transferProxy, takerWalletWrapper.address);
   });
 

--- a/utils/exchangeWrapper.ts
+++ b/utils/exchangeWrapper.ts
@@ -31,6 +31,7 @@ export class ExchangeWrapper {
   /* ============ Deployment ============ */
 
   public async deployKyberNetworkWrapper(
+    core: Address,
     kyberNetworkProxy: Address,
     transferProxy: TransferProxyContract,
     from: Address = this._contractOwnerAddress
@@ -41,6 +42,7 @@ export class ExchangeWrapper {
 
     await KyberNetworkWrapper.link('ERC20Wrapper', truffleERC20Wrapper.address);
     const kyberNetworkWrapperInstance = await KyberNetworkWrapper.new(
+      core,
       kyberNetworkProxy,
       transferProxy.address,
       { from, gas: DEFAULT_GAS },
@@ -53,20 +55,20 @@ export class ExchangeWrapper {
   }
 
   public async deployAndAuthorizeKyberNetworkWrapper(
+    core: CoreContract,
     kyberNetworkProxy: Address,
     transferProxy: TransferProxyContract,
-    core: CoreContract,
     from: Address = this._contractOwnerAddress
   ): Promise<KyberNetworkWrapperContract> {
-    const kyberNetworkWrapper = await this.deployKyberNetworkWrapper(kyberNetworkProxy, transferProxy);
+    const kyberNetworkWrapper = await this.deployKyberNetworkWrapper(core.address, kyberNetworkProxy, transferProxy);
 
     await this._coreWrapper.registerExchange(core, SetUtils.EXCHANGES.KYBER, kyberNetworkWrapper.address);
-    await this._coreWrapper.addAuthorizationAsync(kyberNetworkWrapper, core.address);
 
     return kyberNetworkWrapper;
   }
 
   public async deployTakerWalletExchangeWrapper(
+    core: Address,
     transferProxy: TransferProxyContract,
     from: Address = this._contractOwnerAddress
   ): Promise<TakerWalletWrapperContract> {
@@ -76,6 +78,7 @@ export class ExchangeWrapper {
 
     await TakerWalletWrapper.link('ERC20Wrapper', truffleERC20Wrapper.address);
     const takerWalletWrapperInstance = await TakerWalletWrapper.new(
+      core,
       transferProxy.address,
       { from, gas: DEFAULT_GAS },
     );
@@ -87,20 +90,20 @@ export class ExchangeWrapper {
   }
 
   public async deployAndAuthorizeTakerWalletExchangeWrapper(
-    transferProxy: TransferProxyContract,
     core: CoreContract,
+    transferProxy: TransferProxyContract,
     from: Address = this._contractOwnerAddress
   ): Promise<TakerWalletWrapperContract> {
-    const takerWalletWrapper = await this.deployTakerWalletExchangeWrapper(transferProxy, from);
+    const takerWalletWrapper = await this.deployTakerWalletExchangeWrapper(core.address, transferProxy, from);
 
     await this._coreWrapper.registerExchange(core, SetUtils.EXCHANGES.TAKER_WALLET, takerWalletWrapper.address);
-    await this._coreWrapper.addAuthorizationAsync(takerWalletWrapper, core.address);
     await this._coreWrapper.addAuthorizationAsync(transferProxy, takerWalletWrapper.address);
 
     return takerWalletWrapper;
   }
 
   public async deployZeroExExchangeWrapper(
+    core: Address,
     zeroExExchange: Address,
     zeroExProxy: Address,
     zeroExTokenAddress: Address,
@@ -113,6 +116,7 @@ export class ExchangeWrapper {
 
     await ZeroExExchangeWrapper.link('ERC20Wrapper', truffleERC20Wrapper.address);
     const zeroExExchangeWrapperInstance = await ZeroExExchangeWrapper.new(
+      core,
       zeroExExchange,
       zeroExProxy,
       zeroExTokenAddress,
@@ -127,22 +131,23 @@ export class ExchangeWrapper {
   }
 
   public async deployAndAuthorizeZeroExExchangeWrapper(
+    core: CoreContract,
     zeroExExchange: Address,
     zeroExProxy: Address,
     zeroExTokenAddress: Address,
     transferProxy: TransferProxyContract,
-    core: CoreContract,
     from: Address = this._contractOwnerAddress
   ): Promise<ZeroExExchangeWrapperContract> {
     const zeroExExchangeWrapper = await this.deployZeroExExchangeWrapper(
+      core.address,
       zeroExExchange,
       zeroExProxy,
       zeroExTokenAddress,
-      transferProxy
+      transferProxy,
+      from
     );
 
     await this._coreWrapper.registerExchange(core, SetUtils.EXCHANGES.ZERO_EX, zeroExExchangeWrapper.address);
-    await this._coreWrapper.addAuthorizationAsync(zeroExExchangeWrapper, core.address);
 
     return zeroExExchangeWrapper;
   }


### PR DESCRIPTION
Removing unnecessary `Authorizable` from some of our contracts.