### PR TITLE
Brian/current set redeem check

### DIFF
--- a/contracts/core/RebalancingSetToken.sol
+++ b/contracts/core/RebalancingSetToken.sol
@@ -236,7 +236,7 @@ contract RebalancingSetToken is
         // Be sure the full proposal period has elapsed
         require(block.timestamp >= proposalStartTime.add(proposalPeriod), "PROPOSAL_PERIOD_NOT_ELAPSED");
 
-        // Get core address from factory
+        // Get core address from factory and create core interface
         address coreAddress = ISetFactory(factory).core();
         ICore core = ICore(coreAddress);
 

--- a/contracts/core/RebalancingSetToken.sol
+++ b/contracts/core/RebalancingSetToken.sol
@@ -236,17 +236,25 @@ contract RebalancingSetToken is
         // Be sure the full proposal period has elapsed
         require(block.timestamp >= proposalStartTime.add(proposalPeriod), "PROPOSAL_PERIOD_NOT_ELAPSED");
 
+        // Get core address from factory
+        address coreAddress = ISetFactory(factory).core();
+        ICore core = ICore(coreAddress);
+
         // Create token arrays needed for auction
         auctionSetUp();
 
-        // Get core address from factory
-        address core = ISetFactory(factory).core();
+        // Get currentSet natural unit
+        uint256 currentSetNaturalUnit = ISetToken(currentSet).naturalUnit();
 
-        // Calculate remainingCurrentSets
-        remainingCurrentSets = unitShares.mul(totalSupply_).div(naturalUnit);
+        // Get remainingCurrentSets and make it divisible by currentSet natural unit
+        remainingCurrentSets = IVault(core.vault()).getOwnerBalance(
+            currentSet,
+            this
+        );
+        remainingCurrentSets = remainingCurrentSets.div(currentSetNaturalUnit).mul(currentSetNaturalUnit);
 
         // Redeem current set held by rebalancing token in vault
-        ICore(core).redeemInVault(currentSet, remainingCurrentSets);
+        core.redeemInVault(currentSet, remainingCurrentSets);
 
         // Update state parameters
         auctionStartTime = block.timestamp;

--- a/test/core/rebalancingSetToken.spec.ts
+++ b/test/core/rebalancingSetToken.spec.ts
@@ -961,7 +961,7 @@ contract('RebalancingSetToken', accounts => {
     });
   });
 
-  describe.only('#rebalance', async () => {
+  describe('#rebalance', async () => {
     let subjectCaller: Address;
     let subjectTimeFastForward: BigNumber;
     let proposalPeriod: BigNumber;

--- a/utils/rebalancingWrapper.ts
+++ b/utils/rebalancingWrapper.ts
@@ -18,6 +18,7 @@ import {
   AUCTION_TIME_INCREMENT,
   DEFAULT_GAS,
   DEFAULT_REBALANCING_NATURAL_UNIT,
+  DEFAULT_UNIT_SHARES,
   ONE_DAY_IN_SECONDS,
   UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
   ZERO,
@@ -221,7 +222,7 @@ export class RebalancingWrapper {
     proposalPeriod: BigNumber,
   ): Promise<RebalancingSetTokenContract> {
     // Generate defualt rebalancingSetToken params
-    const initialUnitShares = new BigNumber(2.5).mul(new BigNumber(10 ** 10));
+    const initialUnitShares = DEFAULT_UNIT_SHARES;
     const rebalanceInterval = ONE_DAY_IN_SECONDS;
     const entranceFee = ZERO;
     const rebalanceFee = ZERO;

--- a/utils/rebalancingWrapper.ts
+++ b/utils/rebalancingWrapper.ts
@@ -220,9 +220,9 @@ export class RebalancingWrapper {
     manager: Address,
     initialSet: Address,
     proposalPeriod: BigNumber,
+    initialUnitShares: BigNumber = DEFAULT_UNIT_SHARES,
   ): Promise<RebalancingSetTokenContract> {
     // Generate defualt rebalancingSetToken params
-    const initialUnitShares = DEFAULT_UNIT_SHARES;
     const rebalanceInterval = ONE_DAY_IN_SECONDS;
     const entranceFee = ZERO;
     const rebalanceFee = ZERO;

--- a/utils/rebalancingWrapper.ts
+++ b/utils/rebalancingWrapper.ts
@@ -18,7 +18,6 @@ import {
   AUCTION_TIME_INCREMENT,
   DEFAULT_GAS,
   DEFAULT_REBALANCING_NATURAL_UNIT,
-  DEFAULT_UNIT_SHARES,
   ONE_DAY_IN_SECONDS,
   UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
   ZERO,
@@ -222,7 +221,7 @@ export class RebalancingWrapper {
     proposalPeriod: BigNumber,
   ): Promise<RebalancingSetTokenContract> {
     // Generate defualt rebalancingSetToken params
-    const initialUnitShares = DEFAULT_UNIT_SHARES;
+    const initialUnitShares = new BigNumber(2.5).mul(new BigNumber(10 ** 10));
     const rebalanceInterval = ONE_DAY_IN_SECONDS;
     const entranceFee = ZERO;
     const rebalanceFee = ZERO;


### PR DESCRIPTION
Make sure that if a rebalancing set token is collateralized by an amount of current set token that isn't a multiple of the natural unit of the current set token then rebalance can still go forward.