### PR TITLE
Add price lib tracking in Core

### DIFF
--- a/contracts/core/extensions/CoreInternal.sol
+++ b/contracts/core/extensions/CoreInternal.sol
@@ -105,6 +105,47 @@ contract CoreInternal is
     }
 
     /**
+     * Add a price library to the mapping of tracked price libraries. Can only be set by
+     * owner of Core.
+     *
+     * @param  _priceLibrary   The address of the Price Library to enable
+     */
+    function enablePriceLibrary(
+        address _priceLibrary
+    )
+        external
+        onlyOwner
+    {
+        // Mark as true in validPriceLibraries mapping
+        state.validPriceLibraries[_priceLibrary] = true;
+
+        // Add to priceLibraries array
+        state.priceLibraries.push(_priceLibrary);
+    }
+
+    /**
+     * Disable a priceLibrary in the mapping of tracked Price Libraries. Can only be disabled
+     * by owner of Core.
+     *
+     * @param  _priceLibrary   The address of the Price Library to disable
+     */
+    function disablePriceLibrary(
+        address _priceLibrary
+    )
+        external
+        onlyOwner
+    {
+        // Verify Library is linked to Core
+        require(state.validPriceLibraries[_priceLibrary], "UNKNOWN_LIBRARY");
+
+        // Mark as false in validPriceLibraries mapping
+        state.validPriceLibraries[_priceLibrary] = false;
+
+        // Find and remove price library from priceLibraries array
+        state.priceLibraries = state.priceLibraries.remove(_priceLibrary);
+    }
+
+    /**
      * Change address that rebalancing protocol fees accrue to
      *
      * @param  _protocolAddress   The protcol fee address

--- a/contracts/core/extensions/CoreInternal.sol
+++ b/contracts/core/extensions/CoreInternal.sol
@@ -105,23 +105,25 @@ contract CoreInternal is
     }
 
     /**
-     * Adds or removes a price library to the mapping of tracked price libraries. Can only be set by
-     * owner of Core.
+     * Adds or removes a price library to the mapping of tracked price libraries. Can only be mutated by
+     * owner of Core
      *
-     * @param  _priceLibrary   The address of the Price Library to enable or disable
+     * @param  _priceLibrary   Address of contract Price Library to enable or disable
+     * @param  _enabled        Whether the pricing library is enabled for use in proposal cycle
      */
-    function setPriceLibrary(
-        address _priceLibrary
+    function setPriceLibraryEnabled(
+        address _priceLibrary,
+        bool _enabled
     )
         external
         onlyOwner
     {
         // Mark as true or false in validPriceLibraries mapping
-        state.validPriceLibraries[_priceLibrary] = !state.validPriceLibraries[_priceLibrary];
+        state.validPriceLibraries[_priceLibrary] = _enabled;
 
-        if (state.validPriceLibraries[_priceLibrary]) {
+        if (_enabled) {
             // Add to priceLibraries array
-            state.priceLibraries.push(_priceLibrary);    
+            state.priceLibraries.push(_priceLibrary);
         } else {
             // Remove from priceLibraries array
             state.priceLibraries = state.priceLibraries.remove(_priceLibrary);

--- a/contracts/core/extensions/CoreInternal.sol
+++ b/contracts/core/extensions/CoreInternal.sol
@@ -105,44 +105,27 @@ contract CoreInternal is
     }
 
     /**
-     * Add a price library to the mapping of tracked price libraries. Can only be set by
+     * Adds or removes a price library to the mapping of tracked price libraries. Can only be set by
      * owner of Core.
      *
-     * @param  _priceLibrary   The address of the Price Library to enable
+     * @param  _priceLibrary   The address of the Price Library to enable or disable
      */
-    function enablePriceLibrary(
+    function setPriceLibrary(
         address _priceLibrary
     )
         external
         onlyOwner
     {
-        // Mark as true in validPriceLibraries mapping
-        state.validPriceLibraries[_priceLibrary] = true;
+        // Mark as true or false in validPriceLibraries mapping
+        state.validPriceLibraries[_priceLibrary] = !state.validPriceLibraries[_priceLibrary];
 
-        // Add to priceLibraries array
-        state.priceLibraries.push(_priceLibrary);
-    }
-
-    /**
-     * Disable a priceLibrary in the mapping of tracked Price Libraries. Can only be disabled
-     * by owner of Core.
-     *
-     * @param  _priceLibrary   The address of the Price Library to disable
-     */
-    function disablePriceLibrary(
-        address _priceLibrary
-    )
-        external
-        onlyOwner
-    {
-        // Verify Library is linked to Core
-        require(state.validPriceLibraries[_priceLibrary], "UNKNOWN_LIBRARY");
-
-        // Mark as false in validPriceLibraries mapping
-        state.validPriceLibraries[_priceLibrary] = false;
-
-        // Find and remove price library from priceLibraries array
-        state.priceLibraries = state.priceLibraries.remove(_priceLibrary);
+        if (state.validPriceLibraries[_priceLibrary]) {
+            // Add to priceLibraries array
+            state.priceLibraries.push(_priceLibrary);    
+        } else {
+            // Remove from priceLibraries array
+            state.priceLibraries = state.priceLibraries.remove(_priceLibrary);
+        }
     }
 
     /**

--- a/contracts/core/interfaces/ICore.sol
+++ b/contracts/core/interfaces/ICore.sol
@@ -127,12 +127,14 @@ interface ICore {
 
     /**
      * Adds or removes a price library to the mapping of tracked price libraries. Can only be set by
-     * owner of Core.
+     * owner of Core
      *
-     * @param  _priceLibrary   The address of the PriceLibrary to enable/disable
+     * @param  _priceLibrary   Address of contract Price Library to enable or disable
+     * @param  _enabled        Whether the pricing library is enabled for use in proposal cycle
      */
-    function setPriceLibrary(
-        address _priceLibrary
+    function setPriceLibraryEnabled(
+        address _priceLibrary,
+        bool _enabled
     )
         external;
 

--- a/contracts/core/interfaces/ICore.sol
+++ b/contracts/core/interfaces/ICore.sol
@@ -126,21 +126,12 @@ interface ICore {
         external;
 
     /**
-     * Add a priceLibrary to the mapping of tracked priceLibraries.
+     * Adds or removes a price library to the mapping of tracked price libraries. Can only be set by
+     * owner of Core.
      *
-     * @param  _priceLibrary   The address of the PriceLibrary to enable
+     * @param  _priceLibrary   The address of the PriceLibrary to enable/disable
      */
-    function enablePriceLibrary(
-        address _priceLibrary
-    )
-        external;
-
-    /**
-     * Disable a priceLibrary in the mapping of tracked priceLibraries.
-     *
-     * @param  _priceLibrary   The address of the PriceLibrary to disable
-     */
-    function disablePriceLibrary(
+    function setPriceLibrary(
         address _priceLibrary
     )
         external;

--- a/contracts/core/interfaces/ICore.sol
+++ b/contracts/core/interfaces/ICore.sol
@@ -126,6 +126,26 @@ interface ICore {
         external;
 
     /**
+     * Add a priceLibrary to the mapping of tracked priceLibraries.
+     *
+     * @param  _priceLibrary   The address of the PriceLibrary to enable
+     */
+    function enablePriceLibrary(
+        address _priceLibrary
+    )
+        external;
+
+    /**
+     * Disable a priceLibrary in the mapping of tracked priceLibraries.
+     *
+     * @param  _priceLibrary   The address of the PriceLibrary to disable
+     */
+    function disablePriceLibrary(
+        address _priceLibrary
+    )
+        external;
+
+    /**
      * Exchanges components for Set Tokens
      *
      * @param  _set          Address of set to issue

--- a/contracts/core/lib/CoreState.sol
+++ b/contracts/core/lib/CoreState.sol
@@ -56,6 +56,12 @@ contract CoreState {
         // Array of tracked SetTokens
         address[] setTokens;
 
+        // Mapping of tracked rebalancing price libraries
+        mapping(address => bool) validPriceLibraries;
+
+        // Array of the tracked rebalancing price libraries
+        address[] priceLibraries;
+
         // Mapping of filled Issuance Orders
         mapping(bytes32 => uint) orderFills;
 
@@ -193,6 +199,35 @@ contract CoreState {
         returns(address[])
     {
         return state.setTokens;
+    }
+
+    /**
+     * Return boolean indicating if address is a valid Rebalancing Price Library.
+     *
+     * @param  _priceLibrary    Price library address
+     * @return bool             Boolean indicating if valid Price Library
+     */
+    function validPriceLibraries(
+        address _priceLibrary
+    )
+        public
+        view
+        returns(bool)
+    {
+        return state.validPriceLibraries[_priceLibrary];
+    }
+
+    /**
+     * Return array of all valid Rebalancing Price Libraries.
+     *
+     * @return address[]      Array of valid Price Libraries
+     */
+    function priceLibraries()
+        public
+        view
+        returns(address[])
+    {
+        return state.priceLibraries;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "precommit": "lint-staged",
     "prepare-test": "yarn setup && yarn transpile",
     "setup": "yarn clean && yarn compile && yarn generate-typings && yarn deploy:development",
-    "test": "yarn prepare-test && truffle test `find transpiled/test -name '*.spec.js'`",
+    "test": "yarn prepare-test && truffle test `find transpiled/test -name 'coreInternal.spec.js'`",
     "test-continuous": "truffle test",
     "transpile": "tsc",
     "prepublishOnly": "yarn dist"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "precommit": "lint-staged",
     "prepare-test": "yarn setup && yarn transpile",
     "setup": "yarn clean && yarn compile && yarn generate-typings && yarn deploy:development",
-    "test": "yarn prepare-test && truffle test `find transpiled/test -name 'coreInternal.spec.js'`",
+    "test": "yarn prepare-test && truffle test `find transpiled/test -name '*.spec.js'`",
     "test-continuous": "truffle test",
     "transpile": "tsc",
     "prepublishOnly": "yarn dist"

--- a/test/contracts/core/extensions/coreInternal.spec.ts
+++ b/test/contracts/core/extensions/coreInternal.spec.ts
@@ -250,20 +250,23 @@ contract('CoreInternal', accounts => {
     });
   });
 
-  describe('#setPriceLibrary', async () => {
+  describe('#setPriceLibraryEnabled', async () => {
     let subjectCaller: Address;
     let subjectPriceLibrary: Address;
+    let subjectEnabled: boolean;
 
     beforeEach(async () => {
       priceLibrary = await rebalancingWrapper.deployLinearAuctionPriceCurveAsync();
 
       subjectCaller = ownerAccount;
       subjectPriceLibrary = priceLibrary.address;
+      subjectEnabled = true;
     });
 
     async function subject(): Promise<string> {
-      return core.setPriceLibrary.sendTransactionAsync(
+      return core.setPriceLibraryEnabled.sendTransactionAsync(
         subjectPriceLibrary,
+        subjectEnabled,
         { from: subjectCaller },
       );
     }
@@ -294,7 +297,9 @@ contract('CoreInternal', accounts => {
 
     describe('when disabling an enabled price library', async () => {
       beforeEach(async () => {
-        await rebalancingWrapper.setPriceLibraryAsync(core, priceLibrary);
+        await rebalancingWrapper.setPriceLibraryEnabledAsync(core, priceLibrary, true);
+
+        subjectEnabled = false;
       });
 
       it('disables priceLibrary address correctly', async () => {

--- a/utils/rebalancingWrapper.ts
+++ b/utils/rebalancingWrapper.ts
@@ -216,12 +216,12 @@ export class RebalancingWrapper {
     );
   }
 
-  public async enablePriceLibraryAsync(
+  public async setPriceLibraryAsync(
     core: CoreLikeContract,
     priceLibrary: ConstantAuctionPriceCurveContract | LinearAuctionPriceCurveContract,
     from: Address = this._tokenOwnerAddress
   ): Promise<void> {
-    await core.enablePriceLibrary.sendTransactionAsync(
+    await core.setPriceLibrary.sendTransactionAsync(
       priceLibrary.address,
       { from }
     );

--- a/utils/rebalancingWrapper.ts
+++ b/utils/rebalancingWrapper.ts
@@ -186,6 +186,8 @@ export class RebalancingWrapper {
     return setTokenArray;
   }
 
+  /* ============ Price Libraries ============ */
+
   public async deployLinearAuctionPriceCurveAsync(
     from: Address = this._tokenOwnerAddress
   ): Promise<LinearAuctionPriceCurveContract> {
@@ -211,6 +213,17 @@ export class RebalancingWrapper {
     return new ConstantAuctionPriceCurveContract(
       new web3.eth.Contract(truffleConstantAuctionPriceCurve.abi, truffleConstantAuctionPriceCurve.address),
       { from, gas: DEFAULT_GAS },
+    );
+  }
+
+  public async enablePriceLibraryAsync(
+    core: CoreLikeContract,
+    priceLibrary: ConstantAuctionPriceCurveContract | LinearAuctionPriceCurveContract,
+    from: Address = this._tokenOwnerAddress
+  ): Promise<void> {
+    await core.enablePriceLibrary.sendTransactionAsync(
+      priceLibrary.address,
+      { from }
     );
   }
 

--- a/utils/rebalancingWrapper.ts
+++ b/utils/rebalancingWrapper.ts
@@ -216,13 +216,15 @@ export class RebalancingWrapper {
     );
   }
 
-  public async setPriceLibraryAsync(
+  public async setPriceLibraryEnabledAsync(
     core: CoreLikeContract,
     priceLibrary: ConstantAuctionPriceCurveContract | LinearAuctionPriceCurveContract,
+    enabled: boolean,
     from: Address = this._tokenOwnerAddress
   ): Promise<void> {
-    await core.setPriceLibrary.sendTransactionAsync(
+    await core.setPriceLibraryEnabled.sendTransactionAsync(
       priceLibrary.address,
+      enabled,
       { from }
     );
   }


### PR DESCRIPTION
Completes this [card](https://trello.com/c/TyeL17Lc/630-coreinternal-new-functions).

Add new functions: addPriceLibrary and removePriceLibrary so that only approved price libraries can be used.