### PR TITLE
Update Order Hash Algo to be EIP712 Compliant

### DIFF
--- a/contracts/core/lib/EIP712Library.sol
+++ b/contracts/core/lib/EIP712Library.sol
@@ -1,0 +1,105 @@
+/*
+    Copyright 2018 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.4.24;
+
+
+/**
+ * @title EIP712Library
+ * @author Set Protocol
+ *
+ * The EIP712 Library contains functions for hashing EIP712 Messages
+ *
+ */
+library EIP712Library {
+    /* ============ Constants ============ */
+
+    // EIP191 header for EIP712 prefix
+    string constant internal EIP191_HEADER = "\x19\x01";
+
+    // EIP712 Domain Name value
+    string constant internal EIP712_DOMAIN_NAME = "Set Protocol";
+
+    // EIP712 Domain Version value
+    string constant internal EIP712_DOMAIN_VERSION = "1";
+
+    // Hash of the EIP712 Domain Separator Schema
+    bytes32 constant internal EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH = keccak256(
+        abi.encodePacked(
+            "EIP712Domain(",
+            "string name,",
+            "string version,",
+            ")"
+        )
+    );
+
+    bytes32 constant internal EIP712_DOMAIN_HASH = keccak256(
+        abi.encodePacked(
+            EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH,
+            keccak256(
+                bytes(EIP712_DOMAIN_NAME)
+            ),
+            keccak256(
+                bytes(EIP712_DOMAIN_VERSION)
+            )
+        )
+    );
+
+    /* ============ Internal Functions ============ */
+
+    /**
+     * Calculates EIP712 encoding for a hash struct in this EIP712 Domain.
+     * @param     hashStruct The EIP712 hash struct.
+     * @return    EIP712 hash applied to this EIP712 Domain.
+     */
+    function hashEIP712Message(bytes32 hashStruct)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes32 eip712DomainHash = EIP712_DOMAIN_HASH;
+
+        // Assembly for more efficient computing:
+        // keccak256(abi.encodePacked(
+        //     EIP191_HEADER,
+        //     EIP712_DOMAIN_HASH,
+        //     hashStruct    
+        // ));
+
+        bytes32 result;
+
+        assembly {
+            // Load free memory pointer
+            let memPtr := mload(64)
+
+            mstore(memPtr, 0x1901000000000000000000000000000000000000000000000000000000000000)  // EIP191 header
+            mstore(add(memPtr, 2), eip712DomainHash)                                            // EIP712 domain hash
+            mstore(add(memPtr, 34), hashStruct)                                                 // Hash of struct
+
+            // Compute hash
+            result := keccak256(memPtr, 66)
+        }
+        return result;
+    }
+
+    function getEIP712DomainHash() internal view returns (bytes32) {
+        return EIP712_DOMAIN_HASH;
+    }
+
+    function getEIP712DomainSeparatorSchemaHash() internal view returns (bytes32) {
+        return EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH;
+    }
+}

--- a/contracts/core/lib/EIP712Library.sol
+++ b/contracts/core/lib/EIP712Library.sol
@@ -73,14 +73,7 @@ library EIP712Library {
         returns (bytes32)
     {
         bytes32 eip712DomainHash = EIP712_DOMAIN_HASH;
-
-        // Assembly for more efficient computing:
-        // keccak256(abi.encodePacked(
-        //     EIP191_HEADER,
-        //     EIP712_DOMAIN_HASH,
-        //     hashStruct    
-        // ));
-
+        
         bytes32 result;
 
         assembly {
@@ -102,7 +95,11 @@ library EIP712Library {
      *
      * @return bytes32          Hash of the EIP712 Set Protocol Domain
      */
-    function getEIP712DomainHash() internal view returns (bytes32) {
+    function getEIP712DomainHash()
+        internal
+        view
+        returns (bytes32)
+    {
         return EIP712_DOMAIN_HASH;
     }
     /**
@@ -110,7 +107,11 @@ library EIP712Library {
      *
      * @return bytes32          Hash of the EIP712 Domain Separator Schema
      */
-    function getEIP712DomainSeparatorSchemaHash() internal view returns (bytes32) {
+    function getEIP712DomainSeparatorSchemaHash()
+        internal
+        view
+        returns (bytes32)
+    {
         return EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH;
     }
 }

--- a/contracts/core/lib/EIP712Library.sol
+++ b/contracts/core/lib/EIP712Library.sol
@@ -61,9 +61,9 @@ library EIP712Library {
     /* ============ Internal Functions ============ */
 
     /**
-     * Calculates EIP712 encoding for a hash struct in this EIP712 Domain.
-     * @param     hashStruct The EIP712 hash struct.
-     * @return    EIP712 hash applied to this EIP712 Domain.
+     * Calculates    EIP712 encoding for a hash struct in this EIP712 Domain.
+     * @param        hashStruct The EIP712 hash struct.
+     * @return       EIP712 hash applied to this EIP712 Domain.
      */
     function hashEIP712Message(bytes32 hashStruct)
         internal
@@ -95,10 +95,19 @@ library EIP712Library {
         return result;
     }
 
+    /**
+     * Returns the EIP712 Domain Hash
+     *
+     * @return bytes32          Hash of the EIP712 Set Protocol Domain
+     */
     function getEIP712DomainHash() internal view returns (bytes32) {
         return EIP712_DOMAIN_HASH;
     }
-
+    /**
+     * Returns the EIP712 Domain Separator Schema Hash
+     *
+     * @return bytes32          Hash of the EIP712 Domain Separator Schema
+     */
     function getEIP712DomainSeparatorSchemaHash() internal view returns (bytes32) {
         return EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH;
     }

--- a/contracts/core/lib/EIP712Library.sol
+++ b/contracts/core/lib/EIP712Library.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.24;
+pragma solidity 0.4.25;
 
 
 /**
@@ -65,7 +65,9 @@ library EIP712Library {
      * @param        hashStruct The EIP712 hash struct.
      * @return       EIP712 hash applied to this EIP712 Domain.
      */
-    function hashEIP712Message(bytes32 hashStruct)
+    function hashEIP712Message(
+        bytes32 hashStruct
+    )
         internal
         pure
         returns (bytes32)

--- a/contracts/core/lib/OrderLibrary.sol
+++ b/contracts/core/lib/OrderLibrary.sol
@@ -32,6 +32,27 @@ library OrderLibrary {
 
     /* ============ Structs ============ */
 
+    // Hash for the EIP712 Order Schema
+    bytes32 constant public EIP712_ORDER_SCHEMA_HASH = keccak256(
+        abi.encodePacked(
+            "IssuanceOrder(",
+            "address setAddress",                
+            "address makerAddress",              
+            "address makerToken",                
+            "address relayerAddress",            
+            "address relayerToken",              
+            "uint256 quantity",                  
+            "uint256 makerTokenAmount",          
+            "uint256 expiration",                
+            "uint256 makerRelayerFee",           
+            "uint256 takerRelayerFee",           
+            "uint256 salt",                      
+            "address[] requiredComponents",      
+            "uint256[] requiredComponentAmounts",
+            ")"
+        )
+    );
+
     /**
      * Struct containing all parameters for the issuance order
      *
@@ -70,6 +91,15 @@ library OrderLibrary {
     /* ============ Internal Functions ============ */
 
     /**
+     * Returns the EIP712 Issuance Order Schema Hash
+     *
+     * @return bytes32          Hash of the Issuance Order Schema
+     */
+    function getEIP712OrderSchemaHash() internal view returns (bytes32) {
+        return EIP712_ORDER_SCHEMA_HASH;
+    }
+
+    /**
      * Create hash of order parameters
      *
      * @param  _addresses                   [setAddress, makerAddress, makerToken, relayerAddress, relayerToken]
@@ -91,6 +121,7 @@ library OrderLibrary {
         // Hash the order parameters
         return keccak256(
             abi.encodePacked(
+                EIP712_ORDER_SCHEMA_HASH,   // EIP 712 order schema hash
                 _addresses[0],              // setAddress
                 _addresses[1],              // makerAddress
                 _addresses[2],              // makerToken

--- a/contracts/core/lib/OrderLibrary.sol
+++ b/contracts/core/lib/OrderLibrary.sol
@@ -94,7 +94,7 @@ library OrderLibrary {
     /* ============ Internal Functions ============ */
 
     /**
-      *  Calculates Keccak-256 hash of the order with the EIP712 Domain.
+      * Calculates Keccak-256 hash of the order with the EIP712 Domain.
       *  
       * @param  _addresses                   [setAddress, makerAddress, makerToken, relayerAddress, relayerToken]
       * @param  _values                      [quantity, makerTokenAmount, expiration, makerRelayerFee, takerRelayerFee, salt]

--- a/contracts/mocks/core/lib/EIP712LibraryMock.sol
+++ b/contracts/mocks/core/lib/EIP712LibraryMock.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.4.24;
+pragma experimental "ABIEncoderV2";
+
+import { EIP712Library } from "../../../core/lib/EIP712Library.sol";
+
+// Mock contract implementation of EIP712Library functions
+contract EIP712LibraryMock {
+    function testGetEIP712DomainHash() public view returns (bytes32) {
+        return EIP712Library.getEIP712DomainHash();
+    }
+
+    function testGetEIP712DomainSeparatorSchemaHash() public view returns (bytes32) {
+        return EIP712Library.getEIP712DomainSeparatorSchemaHash();
+    }
+
+    function testHashEIP712Message(bytes32 hashStruct) public view returns (bytes32) {
+        return EIP712Library.hashEIP712Message(hashStruct);
+    }
+}

--- a/contracts/mocks/core/lib/EIP712LibraryMock.sol
+++ b/contracts/mocks/core/lib/EIP712LibraryMock.sol
@@ -5,15 +5,29 @@ import { EIP712Library } from "../../../core/lib/EIP712Library.sol";
 
 // Mock contract implementation of EIP712Library functions
 contract EIP712LibraryMock {
-    function testGetEIP712DomainHash() public view returns (bytes32) {
+    function testGetEIP712DomainHash()
+    	public
+    	view
+    	returns (bytes32)
+	{
         return EIP712Library.getEIP712DomainHash();
     }
 
-    function testGetEIP712DomainSeparatorSchemaHash() public view returns (bytes32) {
+    function testGetEIP712DomainSeparatorSchemaHash()
+    	public
+    	view
+    	returns (bytes32)
+	{
         return EIP712Library.getEIP712DomainSeparatorSchemaHash();
     }
 
-    function testHashEIP712Message(bytes32 hashStruct) public view returns (bytes32) {
+    function testHashEIP712Message(
+    	bytes32 hashStruct
+	)
+		public
+		view
+		returns (bytes32)
+	{
         return EIP712Library.hashEIP712Message(hashStruct);
     }
 }

--- a/contracts/mocks/core/lib/EIP712LibraryMock.sol
+++ b/contracts/mocks/core/lib/EIP712LibraryMock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.4.25;
 pragma experimental "ABIEncoderV2";
 
 import { EIP712Library } from "../../../core/lib/EIP712Library.sol";

--- a/contracts/mocks/core/lib/OrderLibraryMock.sol
+++ b/contracts/mocks/core/lib/OrderLibraryMock.sol
@@ -5,6 +5,10 @@ import { OrderLibrary } from "../../../core/lib/OrderLibrary.sol";
 
 // Mock contract implementation of OrderLibrary functions
 contract OrderLibraryMock {
+    function testGetEIP712OrderSchemaHash() public view returns (bytes32) {
+        return OrderLibrary.getEIP712OrderSchemaHash();
+    }
+
     function testGenerateOrderHash(
         address[5] _addresses,
         uint[6] _values,

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
     "module-alias": "^2.1.0",
-    "set-protocol-utils": "^1.0.0-beta.13",
+    "set-protocol-utils": "^1.0.0-beta.16",
     "sol-trace-set": "^0.0.1",
     "solium": "^1.1.7",
     "tiny-promisify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
     "module-alias": "^2.1.0",
+    "openzeppelin-solidity": "^2.0.0",
     "set-protocol-utils": "^1.0.0-beta.17",
     "sol-trace-set": "^0.0.1",
     "solium": "^1.1.7",
@@ -96,8 +97,7 @@
     "truffle-hdwallet-provider": "^1.0.0-web3one.0",
     "tslint-eslint-rules": "^5.3.1",
     "web3": "1.0.0-beta.36",
-    "web3-utils": "1.0.0-beta.36",
-    "zeppelin-solidity": "^1.10.0"
+    "web3-utils": "1.0.0-beta.36"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "precommit": "lint-staged",
     "prepare-test": "yarn setup && yarn transpile",
     "setup": "yarn clean && yarn compile && yarn generate-typings && yarn deploy:development",
-    "test": "yarn prepare-test && truffle test `find transpiled/test -name 'orderLibrary.spec.js'`",
+    "test": "yarn prepare-test && truffle test `find transpiled/test -name '*.spec.js'`",
     "test-continuous": "truffle test",
     "transpile": "tsc",
     "prepublishOnly": "yarn dist"
@@ -97,7 +97,7 @@
     "tslint-eslint-rules": "^5.3.1",
     "web3": "1.0.0-beta.36",
     "web3-utils": "1.0.0-beta.36",
-    "openzeppelin-solidity": "^2.0.0"
+    "zeppelin-solidity": "^1.10.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "precommit": "lint-staged",
     "prepare-test": "yarn setup && yarn transpile",
     "setup": "yarn clean && yarn compile && yarn generate-typings && yarn deploy:development",
-    "test": "yarn prepare-test && truffle test `find transpiled/test -name '*.spec.js'`",
+    "test": "yarn prepare-test && truffle test `find transpiled/test -name 'orderLibrary.spec.js'`",
     "test-continuous": "truffle test",
     "transpile": "tsc",
     "prepublishOnly": "yarn dist"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
     "module-alias": "^2.1.0",
-    "set-protocol-utils": "^1.0.0-beta.16",
+    "set-protocol-utils": "^1.0.0-beta.17",
     "sol-trace-set": "^0.0.1",
     "solium": "^1.1.7",
     "tiny-promisify": "^1.0.0",

--- a/test/contracts/core/lib/eip712Library.spec.ts
+++ b/test/contracts/core/lib/eip712Library.spec.ts
@@ -1,0 +1,80 @@
+require('module-alias/register');
+
+import * as chai from 'chai';
+import { Bytes } from 'set-protocol-utils';
+
+import { EIP712LibraryMockContract } from '@utils/contracts';
+import { CoreWrapper } from '@utils/coreWrapper';
+import { Blockchain } from '@utils/blockchain';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import ChaiSetup from '@utils/chaiSetup';
+import { getWeb3 } from '@utils/web3Helper';
+
+BigNumberSetup.configure();
+ChaiSetup.configure();
+const web3 = getWeb3();
+const { expect } = chai;
+const blockchain = new Blockchain(web3);
+
+
+contract('EIP712Library', accounts => {
+  const [
+    ownerAccount,
+  ] = accounts;
+
+  let eip712Lib: EIP712LibraryMockContract;
+
+  const coreWrapper = new CoreWrapper(ownerAccount, ownerAccount);
+
+  beforeEach(async () => {
+    await blockchain.saveSnapshotAsync();
+
+    eip712Lib = await coreWrapper.deployMockEIP712LibAsync();
+  });
+
+  afterEach(async () => {
+    await blockchain.revertAsync();
+  });
+
+  describe('#getEIP712DomainHash', async () => {
+    const expectedEIP712Hash: Bytes = '0xa8dcc602486c63f3c678c9b3c5d615c4d6ab4b7d51868af6881272b5d8bb31ff';
+
+    async function subject(): Promise<string> {
+      return eip712Lib.testGetEIP712DomainHash.callAsync();
+    }
+
+    it('should return the correct hash', async () => {
+      const returnedHash = await subject();
+      expect(returnedHash).to.equal(expectedEIP712Hash);
+    });
+  });
+
+  describe('#getEIP712DomainSeparatorSchemaHash', async () => {
+    const expectedEIP712Hash: Bytes = '0x4c2212af4ffd7e170315f531795cee6c22f874d8f5fab37dfa8ed65e616773d2';
+
+    async function subject(): Promise<string> {
+      return eip712Lib.testGetEIP712DomainSeparatorSchemaHash.callAsync();
+    }
+
+    it('should return the correct hash', async () => {
+      const returnedHash = await subject();
+      expect(returnedHash).to.equal(expectedEIP712Hash);
+    });
+  });
+
+  describe('#hashEIP712Message', async () => {
+    const subjectHashStruct: Bytes = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+    async function subject(): Promise<string> {
+      return eip712Lib.testHashEIP712Message.callAsync(
+        subjectHashStruct,
+      );
+    }
+
+    it('should return the correct hash', async () => {
+      const expectedHash = '0x5686079a65f95107943e531f6f7f755044148600233246c75fdce6e59c85cae5';
+      const returnedHash = await subject();
+      expect(returnedHash).to.equal(expectedHash);
+    });
+  });
+});

--- a/test/contracts/core/lib/eip712Library.spec.ts
+++ b/test/contracts/core/lib/eip712Library.spec.ts
@@ -37,27 +37,27 @@ contract('EIP712Library', accounts => {
   });
 
   describe('#getEIP712DomainHash', async () => {
-    const expectedEIP712Hash: Bytes = '0xa8dcc602486c63f3c678c9b3c5d615c4d6ab4b7d51868af6881272b5d8bb31ff';
-
     async function subject(): Promise<string> {
       return eip712Lib.testGetEIP712DomainHash.callAsync();
     }
 
     it('should return the correct hash', async () => {
       const returnedHash = await subject();
+
+      const expectedEIP712Hash: Bytes = '0xa8dcc602486c63f3c678c9b3c5d615c4d6ab4b7d51868af6881272b5d8bb31ff';
       expect(returnedHash).to.equal(expectedEIP712Hash);
     });
   });
 
   describe('#getEIP712DomainSeparatorSchemaHash', async () => {
-    const expectedEIP712Hash: Bytes = '0x4c2212af4ffd7e170315f531795cee6c22f874d8f5fab37dfa8ed65e616773d2';
-
     async function subject(): Promise<string> {
       return eip712Lib.testGetEIP712DomainSeparatorSchemaHash.callAsync();
     }
 
     it('should return the correct hash', async () => {
       const returnedHash = await subject();
+
+      const expectedEIP712Hash: Bytes = '0x4c2212af4ffd7e170315f531795cee6c22f874d8f5fab37dfa8ed65e616773d2';
       expect(returnedHash).to.equal(expectedEIP712Hash);
     });
   });
@@ -72,8 +72,9 @@ contract('EIP712Library', accounts => {
     }
 
     it('should return the correct hash', async () => {
-      const expectedHash = '0x5686079a65f95107943e531f6f7f755044148600233246c75fdce6e59c85cae5';
       const returnedHash = await subject();
+
+      const expectedHash = '0x5686079a65f95107943e531f6f7f755044148600233246c75fdce6e59c85cae5';
       expect(returnedHash).to.equal(expectedHash);
     });
   });

--- a/test/contracts/core/lib/orderLibrary.spec.ts
+++ b/test/contracts/core/lib/orderLibrary.spec.ts
@@ -2,7 +2,7 @@ require('module-alias/register');
 
 import * as chai from 'chai';
 import { BigNumber } from 'bignumber.js';
-import { Address } from 'set-protocol-utils';
+import { Address, Bytes } from 'set-protocol-utils';
 
 import { OrderLibraryMockContract } from '@utils/contracts';
 import { CoreWrapper } from '@utils/coreWrapper';
@@ -45,6 +45,19 @@ contract('OrderLibrary', accounts => {
 
   afterEach(async () => {
     await blockchain.revertAsync();
+  });
+
+  describe('#getEIP712OrderSchemaHash', async () => {
+    const expectedEIP712Hash: Bytes = '0x4afd830c587fce611387a38350e760b2d2fb1b2b469a292353fe64b76cb4f3c4';
+
+    async function subject(): Promise<string> {
+      return orderLib.testGetEIP712OrderSchemaHash.callAsync();
+    }
+
+    it.only('should return the correct hash', async () => {
+      const eip712Hash = await subject();
+      expect(eip712Hash).to.equal(expectedEIP712Hash);
+    });
   });
 
   describe('#validateSignature', async () => {

--- a/test/contracts/core/lib/orderLibrary.spec.ts
+++ b/test/contracts/core/lib/orderLibrary.spec.ts
@@ -183,7 +183,7 @@ contract('OrderLibrary', accounts => {
       );
     }
 
-    it.only('off and on-chain orderHashes should match', async () => {
+    it('off and on-chain orderHashes should match', async () => {
       const contractOrderHash = await subject();
 
       expect(contractOrderHash).to.equal(issuanceOrderParams.orderHash);

--- a/test/contracts/core/lib/orderLibrary.spec.ts
+++ b/test/contracts/core/lib/orderLibrary.spec.ts
@@ -54,7 +54,7 @@ contract('OrderLibrary', accounts => {
       return orderLib.testGetEIP712OrderSchemaHash.callAsync();
     }
 
-    it.only('should return the correct hash', async () => {
+    it('should return the correct hash', async () => {
       const eip712Hash = await subject();
       expect(eip712Hash).to.equal(expectedEIP712Hash);
     });
@@ -183,7 +183,7 @@ contract('OrderLibrary', accounts => {
       );
     }
 
-    it('off and on-chain orderHashes should match', async () => {
+    it.only('off and on-chain orderHashes should match', async () => {
       const contractOrderHash = await subject();
 
       expect(contractOrderHash).to.equal(issuanceOrderParams.orderHash);

--- a/utils/contracts.ts
+++ b/utils/contracts.ts
@@ -1,5 +1,7 @@
 import { BaseContract } from '../types/base_contract';
 
+import { EIP712LibraryContract } from '../types/generated/e_i_p712_library';
+import { EIP712LibraryMockContract } from '../types/generated/e_i_p712_library_mock';
 import { AuthorizableContract } from '../types/generated/authorizable';
 import { BadTokenMockContract } from '../types/generated/bad_token_mock';
 import { Bytes32MockContract } from '../types/generated/bytes32_mock';
@@ -28,6 +30,8 @@ import { ZeroExExchangeWrapperContract } from '../types/generated/zero_ex_exchan
 import { ZeroExOrderDataHandlerMockContract } from '../types/generated/zero_ex_order_data_handler_mock';
 
 export {
+  EIP712LibraryContract,
+  EIP712LibraryMockContract,
   BaseContract,
   AuthorizableContract,
   BadTokenMockContract,

--- a/utils/coreWrapper.ts
+++ b/utils/coreWrapper.ts
@@ -6,6 +6,7 @@ import {
   AuthorizableContract,
   CoreContract,
   CoreMockContract,
+  EIP712LibraryMockContract,
   OrderLibraryMockContract,
   SetTokenContract,
   RebalancingSetTokenContract,
@@ -26,6 +27,8 @@ const web3 = getWeb3();
 const Authorizable = artifacts.require('Authorizable');
 const Core = artifacts.require('Core');
 const CoreMock = artifacts.require('CoreMock');
+const EIP712Library = artifacts.require('EIP712Library');
+const EIP712LibraryMock = artifacts.require('EIP712LibraryMock');
 const ERC20Wrapper = artifacts.require('ERC20Wrapper');
 const OrderLibrary = artifacts.require('OrderLibrary');
 const OrderLibraryMock = artifacts.require('OrderLibraryMock');
@@ -150,6 +153,24 @@ export class CoreWrapper {
 
     return new OrderLibraryMockContract(
       new web3.eth.Contract(truffleOrderLibraryMock.abi, truffleOrderLibraryMock.address),
+      { from, gas: DEFAULT_GAS },
+    );
+  }
+
+  public async deployMockEIP712LibAsync(
+    from: Address = this._tokenOwnerAddress
+  ): Promise<EIP712LibraryMockContract> {
+    const truffleEIP712Library = await EIP712Library.new(
+      { from: this._tokenOwnerAddress },
+    );
+
+    await EIP712LibraryMock.link('EIP712Library', truffleEIP712Library.address);
+    const truffleEIP712LibraryMock = await EIP712LibraryMock.new(
+      { from },
+    );
+
+    return new EIP712LibraryMockContract(
+      new web3.eth.Contract(truffleEIP712LibraryMock.abi, truffleEIP712LibraryMock.address),
       { from, gas: DEFAULT_GAS },
     );
   }

--- a/utils/coreWrapper.ts
+++ b/utils/coreWrapper.ts
@@ -213,10 +213,15 @@ export class CoreWrapper {
       { from: this._tokenOwnerAddress },
     );
 
+    const truffleEIP712Library = await EIP712Library.new(
+      { from: this._tokenOwnerAddress },
+    );
+
     const transferProxy = await this.deployTransferProxyAsync();
     const vault = await this.deployTransferProxyAsync();
 
     await Core.link('OrderLibrary', truffleOrderLibrary.address);
+    await Core.link('EIP712Library', truffleEIP712Library.address);
     const truffleCore = await Core.new(
       transferProxy.address,
       vault.address,
@@ -238,7 +243,12 @@ export class CoreWrapper {
       { from: this._tokenOwnerAddress },
     );
 
+    const truffleEIP712Library = await EIP712Library.new(
+      { from: this._tokenOwnerAddress },
+    );
+
     await Core.link('OrderLibrary', truffleOrderLibrary.address);
+    await Core.link('EIP712Library', truffleEIP712Library.address);
     const truffleCore = await Core.new(
       transferProxy.address,
       vault.address,
@@ -259,8 +269,12 @@ export class CoreWrapper {
     const truffleOrderLibrary = await OrderLibrary.new(
       { from: this._tokenOwnerAddress },
     );
+     const truffleEIP712Library = await EIP712Library.new(
+      { from: this._tokenOwnerAddress },
+    );
 
     await Core.link('OrderLibrary', truffleOrderLibrary.address);
+    await Core.link('EIP712Library', truffleEIP712Library.address);
     const truffleCore = await CoreMock.new(
       transferProxy.address,
       vault.address,

--- a/utils/orders.ts
+++ b/utils/orders.ts
@@ -44,6 +44,8 @@ export async function generateFillOrderParameters(
     requiredComponentAmounts,
   } as IssuanceOrder;
 
+  console.log('Order', JSON.stringify(order));
+
   const addresses = [
     order.setAddress,
     order.makerAddress,

--- a/utils/orders.ts
+++ b/utils/orders.ts
@@ -44,8 +44,6 @@ export async function generateFillOrderParameters(
     requiredComponentAmounts,
   } as IssuanceOrder;
 
-  console.log('Order', JSON.stringify(order));
-
   const addresses = [
     order.setAddress,
     order.makerAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@0xproject/assert@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@0xproject/assert/-/assert-1.0.13.tgz#e370ccce08933dd2a970bdd02b92e59c65dd75d4"
+  integrity sha512-qL9++/HspndCP7CvvMJ6ns7vJUyQDIlwt93hYJz9IoqL6fDsU+smSEwUpGMExlS/zotCc3MMgliuT5uaH1t1kw==
+  dependencies:
+    "@0xproject/json-schemas" "^1.0.7"
+    "@0xproject/typescript-typings" "^3.0.2"
+    "@0xproject/utils" "^2.0.2"
+    lodash "^4.17.5"
+    valid-url "^1.0.9"
+
 "@0xproject/assert@^1.0.5", "@0xproject/assert@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@0xproject/assert/-/assert-1.0.6.tgz#871e5d3426ae5324ab2cee93235c6b067f6610fb"
@@ -10,17 +21,6 @@
     "@0xproject/json-schemas" "^1.0.1-rc.5"
     "@0xproject/typescript-typings" "^1.0.5"
     "@0xproject/utils" "^1.0.6"
-    lodash "^4.17.5"
-    valid-url "^1.0.9"
-
-"@0xproject/assert@^1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@0xproject/assert/-/assert-1.0.9.tgz#01676bf49b6c8702dab421a36fb1afa93718f31b"
-  integrity sha512-jvwk7yi7yFfyRKNwr/+tkfWoaw6VQAtANW/aI5qiKV/4BuuUipIZeZSQc5RzdBY9ag7L/Tp9/HcO9h1g4o7GZQ==
-  dependencies:
-    "@0xproject/json-schemas" "^1.0.2"
-    "@0xproject/typescript-typings" "^2.0.1"
-    "@0xproject/utils" "^1.0.9"
     lodash "^4.17.5"
     valid-url "^1.0.9"
 
@@ -48,16 +48,16 @@
     ethers "3.0.22"
     lodash "^4.17.5"
 
-"@0xproject/base-contract@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@0xproject/base-contract/-/base-contract-2.0.3.tgz#37c789730ae3b0fb4a460bd8816a1555f70730fe"
-  integrity sha512-PuQ1EA9+Y1mvo5wu2AC0cLQWS2Iow4cnFY+hldpWzTfuCUa8KVwpzMDDD/UPxj8FhSxb8xTxTBsnjBwKLoHL/g==
+"@0xproject/base-contract@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@0xproject/base-contract/-/base-contract-3.0.1.tgz#ae6ff8c4492affcb015324d6a1a8de72b22e1f8b"
+  integrity sha512-iIh9124cQ+iwSaJ6PQSYH4CLaSjaojEWAk1Oj39ND5uFQ8wna+8X5wOuI7L7iogoXBhvHAQ8uJe3Wy+zhxQeMg==
   dependencies:
-    "@0xproject/typescript-typings" "^2.0.1"
-    "@0xproject/utils" "^1.0.9"
-    "@0xproject/web3-wrapper" "^2.0.3"
-    ethereum-types "^1.0.7"
-    ethers "3.0.22"
+    "@0xproject/typescript-typings" "^3.0.2"
+    "@0xproject/utils" "^2.0.2"
+    "@0xproject/web3-wrapper" "^3.0.3"
+    ethereum-types "^1.0.11"
+    ethers "4.0.0-beta.14"
     lodash "^4.17.5"
 
 "@0xproject/json-schemas@^1.0.1-rc.4", "@0xproject/json-schemas@^1.0.1-rc.5":
@@ -70,34 +70,34 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0xproject/json-schemas@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@0xproject/json-schemas/-/json-schemas-1.0.2.tgz#baabcf8dd8286ddb11204d9b590e0c2e3a26deea"
-  integrity sha512-Ka69rsBGlQ/lXVaydfzs2ivZPIzpP8h2rzNiCpZXB5bU9E5LDHSxZaKui0QpiAcnbR9yqbhNxzbeZCKvVwULew==
+"@0xproject/json-schemas@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@0xproject/json-schemas/-/json-schemas-1.0.7.tgz#64b5692a1bcc5938ce2da01fc2f8aecd72ec35be"
+  integrity sha512-A4oG8lrA+YFAyzBIKoREVNbTrgCjJ5gvl462my+tTO3kkouR8zP/tk8LW++2C17wfraYZ0gXjbKP7WCEaHnQAw==
   dependencies:
-    "@0xproject/typescript-typings" "^2.0.1"
+    "@0xproject/typescript-typings" "^3.0.2"
     "@types/node" "*"
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0xproject/order-utils@^1.0.1-rc.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@0xproject/order-utils/-/order-utils-1.0.3.tgz#7a9c32bcc96cd244456093bac59fa05587f1fa26"
-  integrity sha512-GkJ3UgAks68q8qUyGd+9U0NT/Gk6g/SvfmZwVj/xV3p0mbiY2R8Lh6WUcn8fT8Xqq34opU+lkGQmXsc6Gtm0Ig==
+"@0xproject/order-utils@^1.0.1":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@0xproject/order-utils/-/order-utils-1.0.7.tgz#475cd5f1a11dc7816847abb4d3fd17bbaf32bf4f"
+  integrity sha512-OgGo1hZY5N4U12T0OXX0ldV0FK/asCLp7f1lwtYjl3ME3riOXxIq5vHun7y1yEgm/VokPUUBODQp5X+FsisACQ==
   dependencies:
-    "@0xproject/assert" "^1.0.9"
-    "@0xproject/base-contract" "^2.0.3"
-    "@0xproject/json-schemas" "^1.0.2"
-    "@0xproject/types" "^1.0.2"
-    "@0xproject/typescript-typings" "^2.0.1"
-    "@0xproject/utils" "^1.0.9"
-    "@0xproject/web3-wrapper" "^2.0.3"
+    "@0xproject/assert" "^1.0.13"
+    "@0xproject/base-contract" "^3.0.1"
+    "@0xproject/json-schemas" "^1.0.7"
+    "@0xproject/types" "^1.1.4"
+    "@0xproject/typescript-typings" "^3.0.2"
+    "@0xproject/utils" "^2.0.2"
+    "@0xproject/web3-wrapper" "^3.0.3"
     "@types/node" "*"
     bn.js "^4.11.8"
-    ethereum-types "^1.0.7"
+    ethereum-types "^1.0.11"
     ethereumjs-abi "0.6.5"
     ethereumjs-util "^5.1.1"
-    ethers "3.0.22"
+    ethers "4.0.0-beta.14"
     lodash "^4.17.5"
 
 "@0xproject/order-utils@^1.0.1-rc.3":
@@ -120,7 +120,7 @@
     ethers "3.0.22"
     lodash "^4.17.5"
 
-"@0xproject/types@^1.0.1-rc.3", "@0xproject/types@^1.0.1-rc.4", "@0xproject/types@^1.0.1-rc.5":
+"@0xproject/types@^1.0.1-rc.4", "@0xproject/types@^1.0.1-rc.5":
   version "1.0.1-rc.5"
   resolved "https://registry.yarnpkg.com/@0xproject/types/-/types-1.0.1-rc.5.tgz#4c403a2fc8795e45034bda2b0e588a77c2767ea2"
   integrity sha512-JaxT9taluHPXMLoBGYYhm4pb/OyhiwFUc5VgwRTdEqUV2f6rQcJGkhU0nScsn/T/moh+nj9IlbNMdJyhpc1dsw==
@@ -129,16 +129,7 @@
     bignumber.js "~4.1.0"
     ethereum-types "^1.0.5"
 
-"@0xproject/types@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@0xproject/types/-/types-1.0.2.tgz#76a7106f6c19b0ed9cde7dc1218dcc4252d3b397"
-  integrity sha512-inT/6cu3R+POs6ejXZzHKaIO8Y95GYKYlGEZiXt7i3+ebO4vGT9YIFJCv+zoE/1Bi/Z0NbR1ldb6hMCqFERc2w==
-  dependencies:
-    "@types/node" "*"
-    bignumber.js "~4.1.0"
-    ethereum-types "^1.0.7"
-
-"@0xproject/types@^1.1.4":
+"@0xproject/types@^1.0.7", "@0xproject/types@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@0xproject/types/-/types-1.1.4.tgz#3ffd65e670d6a21dab19ee0ffd5fad0056291b8e"
   integrity sha512-kPVXvVDDoHhi/q3PSe3F5NbBFiIT8FfPG73J2WrLrXptf54vTSffbK3D+NMpwb12tk/q0KgdEPwNz6nhY1+xmw==
@@ -156,17 +147,6 @@
     "@types/react" "*"
     bignumber.js "~4.1.0"
     ethereum-types "^1.0.5"
-    popper.js "1.14.3"
-
-"@0xproject/typescript-typings@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@0xproject/typescript-typings/-/typescript-typings-2.0.1.tgz#328e80d650092a2e1a7b156796a401811b066df6"
-  integrity sha512-6FM3eqXpHvNphyaHF9tENUJfa1H2X/I4l8YBlcz7BGZQx6ysz/YGo+797N+h4lC6Fx1Oh/EI+uK5sadzHXERYw==
-  dependencies:
-    "@types/bn.js" "^4.11.0"
-    "@types/react" "*"
-    bignumber.js "~4.1.0"
-    ethereum-types "^1.0.7"
     popper.js "1.14.3"
 
 "@0xproject/typescript-typings@^3.0.2":
@@ -192,24 +172,6 @@
     bignumber.js "~4.1.0"
     detect-node "2.0.3"
     ethereum-types "^1.0.5"
-    ethereumjs-util "^5.1.1"
-    ethers "3.0.22"
-    isomorphic-fetch "^2.2.1"
-    js-sha3 "^0.7.0"
-    lodash "^4.17.5"
-
-"@0xproject/utils@^1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@0xproject/utils/-/utils-1.0.9.tgz#6154f69d5618f4675e9429879b59e6162ee5d985"
-  integrity sha512-pEtcjvfxk4yitZL8+6HE4OGvJWPmWdZhLV9ITD8EKXme+tfKvveQ3/Y/BWXRkA0l3wM3ZIqo/9ZK8sH3J5A45g==
-  dependencies:
-    "@0xproject/types" "^1.0.2"
-    "@0xproject/typescript-typings" "^2.0.1"
-    "@types/node" "*"
-    abortcontroller-polyfill "^1.1.9"
-    bignumber.js "~4.1.0"
-    detect-node "2.0.3"
-    ethereum-types "^1.0.7"
     ethereumjs-util "^5.1.1"
     ethers "3.0.22"
     isomorphic-fetch "^2.2.1"
@@ -262,18 +224,18 @@
     ethers "3.0.22"
     lodash "^4.17.5"
 
-"@0xproject/web3-wrapper@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@0xproject/web3-wrapper/-/web3-wrapper-2.0.3.tgz#fe5e9950f36261ea3c6c798639376f0bcef092d0"
-  integrity sha512-89wz5Qr0cy5PSq9vwtB1zOCPwzhAfuziEUtbccvYWm/+M4tWKgp91DEhIy/wYbORZ+i63+0f5y0DHn2iJWXyYQ==
+"@0xproject/web3-wrapper@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@0xproject/web3-wrapper/-/web3-wrapper-3.0.3.tgz#2faaf3fa75308480efbbbb75416a1e416596d989"
+  integrity sha512-eSg60Q/H2H7A7/gEcfUeUhcz9svgd+zyfLhjnBCpqNS4j0Qdy359ZVb+mGjJk5w+8seAXMLKYDNb1HTr2dmtYg==
   dependencies:
-    "@0xproject/assert" "^1.0.9"
-    "@0xproject/json-schemas" "^1.0.2"
-    "@0xproject/typescript-typings" "^2.0.1"
-    "@0xproject/utils" "^1.0.9"
-    ethereum-types "^1.0.7"
+    "@0xproject/assert" "^1.0.13"
+    "@0xproject/json-schemas" "^1.0.7"
+    "@0xproject/typescript-typings" "^3.0.2"
+    "@0xproject/utils" "^2.0.2"
+    ethereum-types "^1.0.11"
     ethereumjs-util "^5.1.1"
-    ethers "3.0.22"
+    ethers "4.0.0-beta.14"
     lodash "^4.17.5"
 
 "@samverschueren/stream-to-observable@^0.3.0":
@@ -2884,14 +2846,6 @@ ethereum-types@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ethereum-types/-/ethereum-types-1.0.11.tgz#bfa9edef392ea51ca95e88794e5621ea8e8c7db0"
   integrity sha512-b8rYKLULe2eDbkbMml/oY60ltKzo0VdPqfkBUk65oqzNOVwIf8V+ODvmbTyz3WxStq4tPS2SgN8WhRMfvnKZJw==
-  dependencies:
-    "@types/node" "*"
-    bignumber.js "~4.1.0"
-
-ethereum-types@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/ethereum-types/-/ethereum-types-1.0.7.tgz#880833ee3dbbf37e9b00cc5c7a635ed91d063992"
-  integrity sha512-QIo9i7zlFZXfR58WAJPEkG7GwMpt0s5CzkrnvKOK5lW8PizehsTNYFrCSJ6p0ZJtM0c+oRUArs2OGzm9dEJGfg==
   dependencies:
     "@types/node" "*"
     bignumber.js "~4.1.0"
@@ -6709,14 +6663,14 @@ set-immediate-shim@^1.0.1:
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
   integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
-set-protocol-utils@^1.0.0-beta.13:
-  version "1.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-1.0.0-beta.13.tgz#7cb17fef0b66c683cebf14356be074786da6813e"
-  integrity sha512-t0pZg+uUQAuGbcuDWLPPoX6uAMcHb0x2deK7NqWTvGGHVNkhxCFoxutZBq8e6/YrTsKR2/Sn5bz00YrBTojXCQ==
+set-protocol-utils@^1.0.0-beta.16:
+  version "1.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-1.0.0-beta.16.tgz#bdfddb849c356cfe82f0675007c91d862b02522e"
+  integrity sha512-vc/m/QIS3GigJAIC+A7gxDbGkFVyFBMHSJf5NiDj8Kz1lvU8xP0mTyG3xuhcOsWJo0jjI9jos3XpcHyYV5Me1Q==
   dependencies:
     "@0xproject/base-contract" "^1.0.4"
-    "@0xproject/order-utils" "^1.0.1-rc.2"
-    "@0xproject/types" "^1.0.1-rc.3"
+    "@0xproject/order-utils" "^1.0.1"
+    "@0xproject/types" "^1.0.7"
     "@0xproject/web3-wrapper" "^1.1.2"
     "@types/lodash" "4.14.104"
     "@types/node" "^8.5.1"
@@ -6729,7 +6683,7 @@ set-protocol-utils@^1.0.0-beta.13:
     chai-as-promised "^7.1.1"
     chai-bignumber "^2.0.2"
     ethereum-types "^1.0.0"
-    ethereumjs-util "^5.1.1"
+    ethereumjs-util "^5.0.0"
     ethers "3.0.22"
     husky "^0.14.3"
     js-sha3 "^0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5612,6 +5612,7 @@ openzeppelin-solidity@^1.10.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz#7b9c55975e73370d4541e3442b30cb3d91ac973a"
   integrity sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA==
+<<<<<<< HEAD
 
 openzeppelin-solidity@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5566,7 +5566,6 @@ openzeppelin-solidity@^1.10.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz#7b9c55975e73370d4541e3442b30cb3d91ac973a"
   integrity sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA==
-<<<<<<< HEAD
 
 openzeppelin-solidity@^2.0.0:
   version "2.0.0"
@@ -6663,10 +6662,10 @@ set-immediate-shim@^1.0.1:
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
   integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
-set-protocol-utils@^1.0.0-beta.16:
-  version "1.0.0-beta.16"
-  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-1.0.0-beta.16.tgz#bdfddb849c356cfe82f0675007c91d862b02522e"
-  integrity sha512-vc/m/QIS3GigJAIC+A7gxDbGkFVyFBMHSJf5NiDj8Kz1lvU8xP0mTyG3xuhcOsWJo0jjI9jos3XpcHyYV5Me1Q==
+set-protocol-utils@^1.0.0-beta.17:
+  version "1.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/set-protocol-utils/-/set-protocol-utils-1.0.0-beta.17.tgz#1437780275627d1478c7ff5167f60a584a116a16"
+  integrity sha512-TwMdKpYrDW/ZxeyV8zFMeFi0v/0VHWPtq/S9XzglAa89sWDp5zz10mYW9cNJTWiUdW6yNttp3BFAPSxLP0xtJw==
   dependencies:
     "@0xproject/base-contract" "^1.0.4"
     "@0xproject/order-utils" "^1.0.1"


### PR DESCRIPTION
This is the first PR to start building abstracting out signatures. 

- EIP712 File mostly taken from [0x](https://github.com/0xProject/0x-monorepo/blob/e62458705039f6a187ff23e4e4ee1737476eb431/packages/contracts/contracts/protocol/Exchange/libs/LibEIP712.sol)
- Also included changes required in set-protocol-utils which has already been merged.