### PR TITLE
Post-Audit Data Validation Fixes

### DIFF
--- a/contracts/core/lib/CoreIssuanceLibrary.sol
+++ b/contracts/core/lib/CoreIssuanceLibrary.sol
@@ -147,11 +147,16 @@ library CoreIssuanceLibrary {
         pure
         returns (uint256[] memory)
     {
+        require(
+            _quantity.mod(_naturalUnit) == 0,
+            "CoreIssuanceLibrary: Quantity must be a multiple of nat unit"
+        );
+
         uint256[] memory tokenValues = new uint256[](_componentUnits.length);
 
         // Transfer the underlying tokens to the corresponding token balances
         for (uint256 i = 0; i < _componentUnits.length; i++) {
-            tokenValues[i] = _quantity.mul(_componentUnits[i]).div(_naturalUnit);
+            tokenValues[i] = _quantity.div(_naturalUnit).mul(_componentUnits[i]);
         }
 
         return tokenValues;

--- a/contracts/core/lib/SetTokenLibrary.sol
+++ b/contracts/core/lib/SetTokenLibrary.sol
@@ -34,7 +34,7 @@ library SetTokenLibrary {
         address _set,
         address[] memory _tokens
     )
-        public
+        external
         view
     {
         for (uint256 i = 0; i < _tokens.length; i++) {

--- a/contracts/core/lib/SetTokenLibrary.sol
+++ b/contracts/core/lib/SetTokenLibrary.sol
@@ -1,0 +1,50 @@
+/*
+    Copyright 2018 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.5.4;
+
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+import { ISetToken} from "../interfaces/ISetToken.sol";
+
+
+library SetTokenLibrary {
+    using SafeMath for uint256;
+
+    /**
+     * Validates that passed in tokens are all components of the Set
+     *
+     * @param _set                      Address of the Set
+     * @param _tokens                   List of tokens to check
+     */
+    function validateTokensAreComponents(
+        address _set,
+        address[] memory _tokens
+    )
+        public
+        view
+    {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            // Make sure all tokens are members of the Set
+            require(
+                ISetToken(_set).tokenIsComponent(_tokens[i]),
+                "SetTokenLibrary.validateTokensAreComponents: Component must be a member of Set"
+            );
+
+        }
+    }
+}
+

--- a/contracts/core/lib/SetTokenLibrary.sol
+++ b/contracts/core/lib/SetTokenLibrary.sol
@@ -32,7 +32,7 @@ library SetTokenLibrary {
      */
     function validateTokensAreComponents(
         address _set,
-        address[] memory _tokens
+        address[] calldata _tokens
     )
         external
         view

--- a/contracts/core/modules/ExchangeIssuanceModule.sol
+++ b/contracts/core/modules/ExchangeIssuanceModule.sol
@@ -24,7 +24,7 @@ import { ExchangeExecution } from "./lib/ExchangeExecution.sol";
 import { ExchangeIssuanceLibrary } from "./lib/ExchangeIssuanceLibrary.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
 import { ModuleCoreState } from "./lib/ModuleCoreState.sol";
-import { SetTokenLibrary } from "./lib/SetTokenLibrary.sol";
+import { SetTokenLibrary } from "../lib/SetTokenLibrary.sol";
 
 
 /**

--- a/contracts/core/modules/ExchangeIssuanceModule.sol
+++ b/contracts/core/modules/ExchangeIssuanceModule.sol
@@ -24,6 +24,7 @@ import { ExchangeExecution } from "./lib/ExchangeExecution.sol";
 import { ExchangeIssuanceLibrary } from "./lib/ExchangeIssuanceLibrary.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
 import { ModuleCoreState } from "./lib/ModuleCoreState.sol";
+import { SetTokenLibrary } from "./lib/SetTokenLibrary.sol";
 
 
 /**
@@ -96,7 +97,7 @@ contract ExchangeIssuanceModule is
         validateExchangeIssuanceParams(_exchangeIssuanceParams);
 
         // Validate that all receiveTokens are components of the SEt
-        validateTokensAreComponents(
+        SetTokenLibrary.validateTokensAreComponents(
             _exchangeIssuanceParams.setAddress,
             _exchangeIssuanceParams.receiveTokens
         );
@@ -146,7 +147,7 @@ contract ExchangeIssuanceModule is
         validateExchangeIssuanceParams(_exchangeIssuanceParams);
 
         // Validate that all sendTokens are components of the Set
-        validateTokensAreComponents(
+        SetTokenLibrary.validateTokensAreComponents(
             _exchangeIssuanceParams.setAddress,
             _exchangeIssuanceParams.sendTokens
         );

--- a/contracts/core/modules/lib/ExchangeExecution.sol
+++ b/contracts/core/modules/lib/ExchangeExecution.sol
@@ -180,27 +180,4 @@ contract ExchangeExecution is
             _exchangeIssuanceParams.receiveTokenAmounts
         );
     }
-
-    /**
-     * Validates that passed in tokens are all components of the Set
-     *
-     * @param _set                      Address of the Set
-     * @param _tokens                   List of tokens to check
-     */
-    function validateTokensAreComponents(
-        address _set,
-        address[] memory _tokens
-    )
-        internal
-        view
-    {
-        for (uint256 i = 0; i < _tokens.length; i++) {
-            // Make sure all tokens are members of the Set
-            require(
-                ISetToken(_set).tokenIsComponent(_tokens[i]),
-                "ExchangeExecution.validateTokensAreComponents: Component must be a member of Set"
-            );
-
-        }
-    }
 }

--- a/contracts/core/modules/lib/ExchangeIssuanceLibrary.sol
+++ b/contracts/core/modules/lib/ExchangeIssuanceLibrary.sol
@@ -18,6 +18,7 @@ pragma solidity 0.5.4;
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+import { AddressArrayUtils } from "../../../lib/AddressArrayUtils.sol";
 import { ICore } from "../../interfaces/ICore.sol";
 import { ISetToken } from "../../interfaces/ISetToken.sol";
 import { IVault } from "../../interfaces/IVault.sol";
@@ -31,6 +32,7 @@ import { IVault } from "../../interfaces/IVault.sol";
  */
 library ExchangeIssuanceLibrary {
     using SafeMath for uint256;
+    using AddressArrayUtils for address[];
 
     // ============ Structs ============
 
@@ -71,7 +73,8 @@ library ExchangeIssuanceLibrary {
     }
 
     /**
-     * Validates that the required Components and amounts are valid components and positive
+     * Validates that the required Components and amounts are valid components and positive.
+     * Duplicate receive token values are not allowed
      *
      * @param _receiveTokens           The addresses of components required for issuance
      * @param _receiveTokenAmounts     The quantities of components required for issuance
@@ -89,6 +92,12 @@ library ExchangeIssuanceLibrary {
         require(
             receiveTokensCount > 0,
             "ExchangeIssuanceLibrary.validateReceiveTokens: Receive tokens must not be empty"
+        );
+
+        // Ensure the receive tokens has no duplicates
+        require(
+            !_receiveTokens.hasDuplicate(),
+            "ExchangeIssuanceLibrary.validateReceiveTokens: Receive tokens must not have duplicates"
         );
 
         // Make sure required components and required component amounts are equal length
@@ -141,7 +150,8 @@ library ExchangeIssuanceLibrary {
     }
 
     /**
-     * Validates that the send tokens inputs are valid
+     * Validates that the send tokens inputs are valid. Since tokens are sent to various exchanges,
+     * duplicate send tokens are valid
      *
      * @param _core                         The address of Core
      * @param _sendTokenExchangeIds         List of exchange wrapper enumerations corresponding to 
@@ -158,6 +168,11 @@ library ExchangeIssuanceLibrary {
         internal
         view
     {
+        require(
+            _sendTokens.length > 0,
+            "ExchangeIssuanceLibrary.validateSendTokenParams: Send token inputs must not be empty"
+        );
+
         require(
             _sendTokenExchangeIds.length == _sendTokens.length && 
             _sendTokens.length == _sendTokenAmounts.length,

--- a/contracts/lib/AddressArrayUtils.sol
+++ b/contracts/lib/AddressArrayUtils.sol
@@ -300,6 +300,9 @@ library AddressArrayUtils {
      * @return Returns true if duplicate, false otherwise
      */
     function hasDuplicate(address[] memory A) internal pure returns (bool) {
+        if (A.length == 0) { 
+            return false;
+        }
         for (uint256 i = 0; i < A.length - 1; i++) {
             for (uint256 j = i + 1; j < A.length; j++) {
                 if (A[i] == A[j]) {

--- a/contracts/mocks/core/lib/CoreIssuanceLibraryMock.sol
+++ b/contracts/mocks/core/lib/CoreIssuanceLibraryMock.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.5.4;
+pragma experimental "ABIEncoderV2";
+
+import { CoreIssuanceLibrary } from "../../../core/lib/CoreIssuanceLibrary.sol";
+
+// Mock contract implementation of CoreIssuanceLibraryMock functions
+contract CoreIssuanceLibraryMock {
+    function testCalculateTransferValues(
+        uint256[] memory _componentUnits,
+        uint256 _naturalUnit,
+        uint256 _quantity
+    )
+        public
+        pure
+        returns (uint256[] memory)
+    {
+        return CoreIssuanceLibrary.calculateTransferValues(
+            _componentUnits,
+            _naturalUnit,
+            _quantity
+        );
+    }
+}

--- a/contracts/mocks/core/lib/ExchangeIssuanceLibraryMock.sol
+++ b/contracts/mocks/core/lib/ExchangeIssuanceLibraryMock.sol
@@ -39,6 +39,19 @@ contract ExchangeIssuanceLibraryMock {
         );
     }
 
+    function testValidateReceiveTokens(
+        address[] memory _receiveTokens,
+        uint256[] memory _receiveTokenAmounts
+    )
+        public
+        view 
+    {
+        ExchangeIssuanceLibrary.validateReceiveTokens(
+            _receiveTokens,
+            _receiveTokenAmounts
+        );
+    }
+
     function testValidateSendTokenParams(
         address _core,
         uint8[] memory _sendTokenExchangeIds,

--- a/contracts/mocks/core/lib/SetTokenLibraryMock.sol
+++ b/contracts/mocks/core/lib/SetTokenLibraryMock.sol
@@ -1,0 +1,24 @@
+pragma solidity 0.5.4;
+pragma experimental "ABIEncoderV2";
+
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import { SetTokenLibrary } from "../../../core/lib/SetTokenLibrary.sol";
+
+
+// Mock class of SetTokenLibrary
+contract SetTokenLibraryMock {
+    using SafeMath for uint256;
+
+    function testValidateTokensAreComponents(
+        address _set,
+        address[] memory _tokens
+    )
+        public
+        view
+    {
+        SetTokenLibrary.validateTokensAreComponents(
+            _set,
+            _tokens
+        );
+    }
+}

--- a/contracts/supplementary/PayableExchangeIssuance.sol
+++ b/contracts/supplementary/PayableExchangeIssuance.sol
@@ -63,15 +63,15 @@ contract PayableExchangeIssuance is
     /* ============ Events ============ */
 
     event LogPayableExchangeIssue(
-        address setAddress,
+        address rebalancingSetAddress,
         address indexed callerAddress,
         uint256 etherQuantity
     );
 
     event LogPayableExchangeRedeem(
-        address setAddress,
+        address rebalancingSetAddress,
         address indexed callerAddress,
-        uint256 etherQuantity
+        uint256 rebalancingSetQuantity
     );
 
     /* ============ Constructor ============ */
@@ -251,7 +251,7 @@ contract PayableExchangeIssuance is
         emit LogPayableExchangeRedeem(
             _rebalancingSetAddress,
             msg.sender,
-            wethBalance
+            _rebalancingSetQuantity
         );
     }
 
@@ -293,7 +293,7 @@ contract PayableExchangeIssuance is
 
     /**
      * Given the issue quantity of the base Set, calculates the maximum quantity of rebalancing Set
-     * issuable.
+     * issuable. Quantity should already be a multiple of the natural unit.
      *
      * @param _rebalancingSetAddress    The address of the rebalancing Set
      * @param _baseSetIssueQuantity     The quantity issued of the base Set

--- a/deployments/stages/1_libraries.ts
+++ b/deployments/stages/1_libraries.ts
@@ -8,6 +8,7 @@ import {
   ERC20WrapperContract,
   ExchangeIssuanceLibraryContract,
   RebalancingHelperLibraryContract,
+  SetTokenLibraryContract,
   StandardFailAuctionLibraryContract,
   StandardPlaceBidLibraryContract,
   StandardProposeLibraryContract,
@@ -19,6 +20,7 @@ import { CoreIssuanceLibrary } from '../../artifacts/ts/CoreIssuanceLibrary';
 import { ERC20Wrapper } from '../../artifacts/ts/ERC20Wrapper';
 import { ExchangeIssuanceLibrary } from '../../artifacts/ts/ExchangeIssuanceLibrary';
 import { RebalancingHelperLibrary } from '../../artifacts/ts/RebalancingHelperLibrary';
+import { SetTokenLibrary } from '../../artifacts/ts/SetTokenLibrary';
 import { StandardFailAuctionLibrary } from '../../artifacts/ts/StandardFailAuctionLibrary';
 import { StandardPlaceBidLibrary } from '../../artifacts/ts/StandardPlaceBidLibrary';
 import { StandardProposeLibrary } from '../../artifacts/ts/StandardProposeLibrary';
@@ -38,6 +40,7 @@ export class LibrariesStage implements DeploymentStageInterface {
     await this.deployCoreIssuanceLibrary();
     await this.deployExchangeIssuanceLibrary();
     await this.deployRebalancingHelperLibrary();
+    await this.deploySetTokenLibrary();
 
     await this.deployStandardProposeLibrary();
     await this.deployStandardSettleRebalanceLibrary();
@@ -93,6 +96,18 @@ export class LibrariesStage implements DeploymentStageInterface {
 
     address = await deployContract(RebalancingHelperLibrary.bytecode, this._web3, name);
     return await RebalancingHelperLibraryContract.at(address, this._web3, TX_DEFAULTS);
+  }
+
+  private async deploySetTokenLibrary(): Promise<SetTokenLibraryContract> {
+    const name = SetTokenLibrary.contractName;
+    let address = await getContractAddress(name);
+
+    if (address) {
+      return await SetTokenLibraryContract.at(address, this._web3, TX_DEFAULTS);
+    }
+
+    address = await deployContract(SetTokenLibrary.bytecode, this._web3, name);
+    return await SetTokenLibraryContract.at(address, this._web3, TX_DEFAULTS);
   }
 
   private async deployStandardProposeLibrary(): Promise<StandardProposeLibraryContract> {

--- a/deployments/stages/3_modules.ts
+++ b/deployments/stages/3_modules.ts
@@ -81,8 +81,6 @@ export class ModulesStage implements DeploymentStageInterface {
       ],
     }).encodeABI();
 
-    console.log("What is data?", data);
-
     address = await deployContract(data, this._web3, name);
     return await ExchangeIssuanceModuleContract.at(address, this._web3, TX_DEFAULTS);
   }

--- a/deployments/stages/3_modules.ts
+++ b/deployments/stages/3_modules.ts
@@ -22,6 +22,7 @@ import { LinearAuctionPriceCurve } from '../../artifacts/ts/LinearAuctionPriceCu
 import { PayableExchangeIssuance } from '../../artifacts/ts/PayableExchangeIssuance';
 import { RebalanceAuctionModule } from '../../artifacts/ts/RebalanceAuctionModule';
 import { RebalancingTokenIssuanceModule } from '../../artifacts/ts/RebalancingTokenIssuanceModule';
+import { SetTokenLibrary } from '../../artifacts/ts/SetTokenLibrary';
 import { TransferProxy } from '../../artifacts/ts/TransferProxy';
 import { Vault } from '../../artifacts/ts/Vault';
 import { ZeroExExchangeWrapper } from '../../artifacts/ts/ZeroExExchangeWrapper';
@@ -65,14 +66,22 @@ export class ModulesStage implements DeploymentStageInterface {
 
     const coreAddress = await getContractAddress(Core.contractName);
     const vaultAddress = await getContractAddress(Vault.contractName);
+    const setTokenLibraryAddress = await getContractAddress(SetTokenLibrary.contractName);
+
+    const originalByteCode = ExchangeIssuanceModule.bytecode;
+    const linkedByteCode = linkLibraries([
+      { name: SetTokenLibrary.contractName, address: setTokenLibraryAddress },
+    ], originalByteCode);
 
     const data = new this._web3.eth.Contract(ExchangeIssuanceModule.abi).deploy({
-      data: ExchangeIssuanceModule.bytecode,
+      data: linkedByteCode,
       arguments: [
         coreAddress,
         vaultAddress,
       ],
     }).encodeABI();
+
+    console.log("What is data?", data);
 
     address = await deployContract(data, this._web3, name);
     return await ExchangeIssuanceModuleContract.at(address, this._web3, TX_DEFAULTS);

--- a/deployments/utils/blockchain.ts
+++ b/deployments/utils/blockchain.ts
@@ -37,7 +37,7 @@ export async function deployContract(bytecode, web3, contractName): Promise<stri
     console.log('Please provide a valid web3 instance');
   }
 
-  if (!web3) {
+  if (!bytecode) {
     console.log('Please provide bytecode/data');
   }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test-scenarios": "yarn prepare-test && yarn truffle-test-scenarios",
     "transpile": "tsc",
     "truffle-test-scenarios": "truffle test `find transpiled/test/scenarios -name '*.spec.js'`",
-    "truffle-test-contracts": "truffle test `find transpiled/test/contracts -name '*.spec.js'`",
+    "truffle-test-contracts": "truffle test `find transpiled/test/contracts -name 'exchangeIssuanceLibraryMock.spec.js'`",
     "prepublishOnly": "yarn dist"
   },
   "repository": "git@github.com:SetProtocol/set-protocol-contracts.git",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test-scenarios": "yarn prepare-test && yarn truffle-test-scenarios",
     "transpile": "tsc",
     "truffle-test-scenarios": "truffle test `find transpiled/test/scenarios -name '*.spec.js'`",
-    "truffle-test-contracts": "truffle test `find transpiled/test/contracts -name 'exchangeIssuanceLibraryMock.spec.js'`",
+    "truffle-test-contracts": "truffle test `find transpiled/test/contracts -name '*.spec.js'`",
     "prepublishOnly": "yarn dist"
   },
   "repository": "git@github.com:SetProtocol/set-protocol-contracts.git",

--- a/test/contracts/core/lib/coreIssuanceLibrary.spec.ts
+++ b/test/contracts/core/lib/coreIssuanceLibrary.spec.ts
@@ -51,7 +51,7 @@ contract('CoreIssuanceLibraryMock', accounts => {
     await blockchain.revertAsync();
   });
 
-  describe('#testValidateReceiveTokens', async () => {
+  describe('#testCalculateTransferValues', async () => {
     let subjectComponentUnits: BigNumber[];
     let subjectNaturalUnit: BigNumber;
     let subjectQuantity: BigNumber;

--- a/test/contracts/core/lib/coreIssuanceLibrary.spec.ts
+++ b/test/contracts/core/lib/coreIssuanceLibrary.spec.ts
@@ -1,0 +1,93 @@
+require('module-alias/register');
+
+import * as _ from 'lodash';
+import * as chai from 'chai';
+import * as ABIDecoder from 'abi-decoder';
+import { BigNumber } from 'bignumber.js';
+
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import {
+  CoreIssuanceLibraryMockContract
+} from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { getWeb3 } from '@utils/web3Helper';
+
+import { LibraryMockWrapper } from '@utils/wrappers/libraryMockWrapper';
+
+BigNumberSetup.configure();
+ChaiSetup.configure();
+const web3 = getWeb3();
+const { expect } = chai;
+const Core = artifacts.require('Core');
+const blockchain = new Blockchain(web3);
+
+
+contract('CoreIssuanceLibraryMock', accounts => {
+  const [
+    contractDeployer,
+  ] = accounts;
+
+  let coreIssuanceLibraryMock: CoreIssuanceLibraryMockContract;
+
+  const libraryMockWrapper = new LibraryMockWrapper(contractDeployer);
+
+  before(async () => {
+    ABIDecoder.addABI(Core.abi);
+  });
+
+  after(async () => {
+    ABIDecoder.removeABI(Core.abi);
+  });
+
+  beforeEach(async () => {
+    await blockchain.saveSnapshotAsync();
+
+    coreIssuanceLibraryMock = await libraryMockWrapper.deployCoreIssuanceLibraryAsync();
+  });
+
+  afterEach(async () => {
+    await blockchain.revertAsync();
+  });
+
+  describe('#testValidateReceiveTokens', async () => {
+    let subjectComponentUnits: BigNumber[];
+    let subjectNaturalUnit: BigNumber;
+    let subjectQuantity: BigNumber;
+
+    beforeEach(async () => {
+      subjectComponentUnits = [new BigNumber(1), new BigNumber(5)];
+      subjectNaturalUnit = new BigNumber(2);
+      subjectQuantity = new BigNumber(4);
+    });
+
+    async function subject(): Promise<any> {
+      return coreIssuanceLibraryMock.testCalculateTransferValues.callAsync(
+        subjectComponentUnits,
+        subjectNaturalUnit,
+        subjectQuantity
+      );
+    }
+
+    it('should return the correct transfer values', async () => {
+      const result = await subject();
+
+      const expectedResult = _.map(
+        subjectComponentUnits, unit => subjectQuantity.div(subjectNaturalUnit).mul(unit)
+      );
+
+      expect(JSON.stringify(result)).to.equal(JSON.stringify(expectedResult));
+    });
+
+    describe('when the quantity is not a multiple of the natural unit', async () => {
+      beforeEach(async () => {
+        subjectQuantity = new BigNumber(5);
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+  });
+});

--- a/test/contracts/core/lib/setTokenLibrary.spec.ts
+++ b/test/contracts/core/lib/setTokenLibrary.spec.ts
@@ -1,0 +1,126 @@
+require('module-alias/register');
+
+import * as _ from 'lodash';
+import * as ABIDecoder from 'abi-decoder';
+import { BigNumber } from 'bignumber.js';
+import { Address } from 'set-protocol-utils';
+
+import ChaiSetup from '@utils/chaiSetup';
+import { BigNumberSetup } from '@utils/bigNumberSetup';
+import {
+  CoreContract,
+  SetTokenContract,
+  SetTokenFactoryContract,
+  SetTokenLibraryMockContract,
+  TransferProxyContract,
+  VaultContract,
+} from '@utils/contracts';
+import { expectRevertError } from '@utils/tokenAssertions';
+import { Blockchain } from '@utils/blockchain';
+import { ether } from '@utils/units';
+import { getWeb3 } from '@utils/web3Helper';
+
+import { LibraryMockWrapper } from '@utils/wrappers/libraryMockWrapper';
+
+import { CoreWrapper } from '@utils/wrappers/coreWrapper';
+import { ERC20Wrapper } from '@utils/wrappers/erc20Wrapper';
+
+BigNumberSetup.configure();
+ChaiSetup.configure();
+const web3 = getWeb3();
+const Core = artifacts.require('Core');
+const blockchain = new Blockchain(web3);
+
+
+contract('SetTokenLibraryMock', accounts => {
+const [
+    contractDeployer,
+    nonComponentAddress,
+  ] = accounts;
+
+  let core: CoreContract;
+  let transferProxy: TransferProxyContract;
+  let vault: VaultContract;
+  let setTokenFactory: SetTokenFactoryContract;
+
+  const coreWrapper = new CoreWrapper(contractDeployer, contractDeployer);
+  const erc20Wrapper = new ERC20Wrapper(contractDeployer);
+
+  let setTokenLibraryMock: SetTokenLibraryMockContract;
+
+  const libraryMockWrapper = new LibraryMockWrapper(contractDeployer);
+
+  before(async () => {
+    ABIDecoder.addABI(Core.abi);
+  });
+
+  after(async () => {
+    ABIDecoder.removeABI(Core.abi);
+  });
+
+  beforeEach(async () => {
+    await blockchain.saveSnapshotAsync();
+
+    vault = await coreWrapper.deployVaultAsync();
+    transferProxy = await coreWrapper.deployTransferProxyAsync();
+    core = await coreWrapper.deployCoreAsync(transferProxy, vault);
+    setTokenFactory = await coreWrapper.deploySetTokenFactoryAsync(core.address);
+    await coreWrapper.setDefaultStateAndAuthorizationsAsync(core, vault, transferProxy, setTokenFactory);
+
+    setTokenLibraryMock = await libraryMockWrapper.deploySetTokenLibraryAsync();
+  });
+
+  afterEach(async () => {
+    await blockchain.revertAsync();
+  });
+
+  describe('#testValidateReceiveTokens', async () => {
+    let subjectSet: Address;
+    let subjectTokens: Address[];
+
+    let setToken: SetTokenContract;
+    let naturalUnit: BigNumber;
+
+    beforeEach(async () => {
+      const firstComponent = await erc20Wrapper.deployTokenAsync(contractDeployer);
+      const secondComponent = await erc20Wrapper.deployTokenAsync(contractDeployer);
+      const componentTokens = [firstComponent, secondComponent];
+      const setComponentUnit = ether(4);
+      const componentAddresses = componentTokens.map(token => token.address);
+      const componentUnits = componentTokens.map(token => setComponentUnit);
+      naturalUnit = ether(2);
+
+      setToken = await coreWrapper.createSetTokenAsync(
+        core,
+        setTokenFactory.address,
+        componentAddresses,
+        componentUnits,
+        naturalUnit,
+      );
+
+      subjectSet = setToken.address;
+      subjectTokens = [firstComponent.address, secondComponent.address];
+    });
+
+    async function subject(): Promise<any> {
+      return setTokenLibraryMock.testValidateTokensAreComponents.callAsync(
+        subjectSet,
+        subjectTokens,
+      );
+    }
+
+    it('should not revert', async () => {
+      await subject();
+    });
+
+    describe('when the quantity is not a multiple of the natural unit', async () => {
+      beforeEach(async () => {
+        subjectTokens = [nonComponentAddress];
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+  });
+});

--- a/test/contracts/core/lib/setTokenLibrary.spec.ts
+++ b/test/contracts/core/lib/setTokenLibrary.spec.ts
@@ -74,7 +74,7 @@ const [
     await blockchain.revertAsync();
   });
 
-  describe('#testValidateReceiveTokens', async () => {
+  describe('#testValidateTokensAreComponents', async () => {
     let subjectSet: Address;
     let subjectTokens: Address[];
 
@@ -113,7 +113,7 @@ const [
       await subject();
     });
 
-    describe('when the quantity is not a multiple of the natural unit', async () => {
+    describe('when the inputted token is not a component', async () => {
       beforeEach(async () => {
         subjectTokens = [nonComponentAddress];
       });

--- a/test/contracts/core/modules/exchangeIssuanceModule.spec.ts
+++ b/test/contracts/core/modules/exchangeIssuanceModule.spec.ts
@@ -489,10 +489,10 @@ contract('ExchangeIssuanceModule', accounts => {
     });
 
     describe('when a receive token is not a member of the Set', async () => {
-      beforeEach(async () => {
-        const notComponent = notExchangeIssueCaller;
-        const notComponent2 = zeroExOrderMaker;
-        exchangeIssueReceiveTokens = [notComponent, notComponent2];
+      before(async () => {
+        const notComponent = await erc20Wrapper.deployTokenAsync(zeroExOrderMaker);
+        const notComponent2 = await erc20Wrapper.deployTokenAsync(zeroExOrderMaker);
+        exchangeIssueReceiveTokens = [notComponent.address, notComponent2.address];
       });
 
       after(async () => {

--- a/test/contracts/core/modules/exchangeIssuanceModule.spec.ts
+++ b/test/contracts/core/modules/exchangeIssuanceModule.spec.ts
@@ -489,9 +489,10 @@ contract('ExchangeIssuanceModule', accounts => {
     });
 
     describe('when a receive token is not a member of the Set', async () => {
-      before(async () => {
+      beforeEach(async () => {
         const notComponent = notExchangeIssueCaller;
-        exchangeIssueReceiveTokens = [notComponent, notComponent];
+        const notComponent2 = zeroExOrderMaker;
+        exchangeIssueReceiveTokens = [notComponent, notComponent2];
       });
 
       after(async () => {

--- a/test/contracts/lib/authorizable.spec.ts
+++ b/test/contracts/lib/authorizable.spec.ts
@@ -23,8 +23,6 @@ const { SetProtocolTestUtils: SetTestUtils } = setProtocolUtils;
 const setTestUtils = new SetTestUtils(web3);
 const { expect } = chai;
 
-
-
 contract('Authorizable', accounts => {
   const [
     ownerAccount,

--- a/test/contracts/supplementary/lib/exchangeIssuanceLibraryMock.spec.ts
+++ b/test/contracts/supplementary/lib/exchangeIssuanceLibraryMock.spec.ts
@@ -130,12 +130,61 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
     });
 
     describe('when Set quantities is zero', async () => {
-      before(async () => {
+      beforeEach(async () => {
         subjectQuantity = ZERO;
       });
 
-      after(async () => {
-       subjectQuantity = undefined;
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+  });
+
+  describe('#testValidateReceiveTokens', async () => {
+    let subjectReceiveTokens: Address[];
+    let subjectReceiveTokenAmounts: BigNumber[];
+
+    beforeEach(async () => {
+      subjectReceiveTokens = [otherAccount];
+      subjectReceiveTokenAmounts = subjectReceiveTokenAmounts || [new BigNumber(1)];
+    });
+
+    async function subject(): Promise<any> {
+      return exchangeIssuanceLibraryMock.testValidateReceiveTokens.callAsync(
+        subjectReceiveTokens,
+        subjectReceiveTokenAmounts
+      );
+    }
+
+    it('should not revert', async () => {
+      await subject();
+    });
+
+    describe('when send tokens has a duplicate', async () => {
+      beforeEach(async () => {
+        subjectReceiveTokens = [otherAccount, otherAccount];
+        subjectReceiveTokenAmounts = [new BigNumber(1), new BigNumber(1)];
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+
+    describe('when send tokens is empty', async () => {
+      beforeEach(async () => {
+        subjectReceiveTokens = [];
+        subjectReceiveTokenAmounts = [];
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+
+    describe('when send quantities quantities is zero', async () => {
+      beforeEach(async () => {
+        subjectReceiveTokenAmounts = [ZERO];
       });
 
       it('should revert', async () => {
@@ -229,6 +278,25 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
 
     it('should not revert', async () => {
       await subject();
+    });
+
+    describe('when send tokens is empty', async () => {
+      before(async () => {
+        subjectSendTokenExchanges = [];
+        subjectSendTokens = [];
+        subjectSendTokenAmounts = [];
+      });
+
+      after(async () => {
+
+        subjectSendTokenExchanges = undefined;
+        subjectSendTokens = undefined;
+        subjectSendTokenAmounts = undefined;
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
     });
 
     describe('when send quantities quantities is zero', async () => {

--- a/test/contracts/supplementary/lib/exchangeIssuanceLibraryMock.spec.ts
+++ b/test/contracts/supplementary/lib/exchangeIssuanceLibraryMock.spec.ts
@@ -239,12 +239,8 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
     });
 
     describe('when required balances does not exceed current vault balance', async () => {
-      before(async () => {
+      beforeEach(async () => {
         subjectReceiveTokenAmounts = [new BigNumber(1000)];
-      });
-
-      after(async () => {
-       subjectReceiveTokenAmounts = undefined;
       });
 
       it('should revert', async () => {
@@ -281,17 +277,10 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
     });
 
     describe('when send tokens is empty', async () => {
-      before(async () => {
+      beforeEach(async () => {
         subjectSendTokenExchanges = [];
         subjectSendTokens = [];
         subjectSendTokenAmounts = [];
-      });
-
-      after(async () => {
-
-        subjectSendTokenExchanges = undefined;
-        subjectSendTokens = undefined;
-        subjectSendTokenAmounts = undefined;
       });
 
       it('should revert', async () => {
@@ -300,12 +289,8 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
     });
 
     describe('when send quantities quantities is zero', async () => {
-      before(async () => {
+      beforeEach(async () => {
         subjectSendTokenAmounts = [ZERO];
-      });
-
-      after(async () => {
-       subjectSendTokenAmounts = undefined;
       });
 
       it('should revert', async () => {

--- a/test/contracts/supplementary/lib/exchangeIssuanceLibraryMock.spec.ts
+++ b/test/contracts/supplementary/lib/exchangeIssuanceLibraryMock.spec.ts
@@ -138,6 +138,16 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
         await expectRevertError(subject());
       });
     });
+
+    describe('when the quantity is not a multiple of the natural unit', async () => {
+      beforeEach(async () => {
+        subjectQuantity = ether(3);
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
   });
 
   describe('#testValidateReceiveTokens', async () => {
@@ -160,7 +170,7 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
       await subject();
     });
 
-    describe('when send tokens has a duplicate', async () => {
+    describe('when receive tokens has a duplicate', async () => {
       beforeEach(async () => {
         subjectReceiveTokens = [otherAccount, otherAccount];
         subjectReceiveTokenAmounts = [new BigNumber(1), new BigNumber(1)];
@@ -171,7 +181,7 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
       });
     });
 
-    describe('when send tokens is empty', async () => {
+    describe('when receive tokens is empty', async () => {
       beforeEach(async () => {
         subjectReceiveTokens = [];
         subjectReceiveTokenAmounts = [];
@@ -182,7 +192,7 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
       });
     });
 
-    describe('when send quantities quantities is zero', async () => {
+    describe('when receive quantities quantities is zero', async () => {
       beforeEach(async () => {
         subjectReceiveTokenAmounts = [ZERO];
       });
@@ -288,7 +298,37 @@ contract('ExchangeIssuanceLibraryMock', accounts => {
       });
     });
 
-    describe('when send quantities quantities is zero', async () => {
+    describe('when send token amounts is uneven', async () => {
+      beforeEach(async () => {
+        subjectSendTokenAmounts = [new BigNumber(1), new BigNumber(2)];
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+
+    describe('when send token exchange ids length is uneven', async () => {
+      beforeEach(async () => {
+        subjectSendTokenExchanges = [new BigNumber(1), new BigNumber(2)];
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+
+    describe('when send token exchange id is invalid', async () => {
+      beforeEach(async () => {
+        subjectSendTokenExchanges = [new BigNumber(4)];
+      });
+
+      it('should revert', async () => {
+        await expectRevertError(subject());
+      });
+    });
+
+    describe('when send token quantities is zero', async () => {
       beforeEach(async () => {
         subjectSendTokenAmounts = [ZERO];
       });

--- a/test/contracts/supplementary/payableExchangeIssuance.spec.ts
+++ b/test/contracts/supplementary/payableExchangeIssuance.spec.ts
@@ -570,7 +570,7 @@ contract('PayableExchangeIssuance', accounts => {
       const expectedLogs = LogPayableExchangeRedeem(
         subjectRebalancingSetAddress,
         subjectCaller,
-        subjectEther,
+        subjectRebalancingSetQuantity,
         payableExchangeIssuance.address
       );
 

--- a/utils/contract_logs/payableExchangeIssuance.ts
+++ b/utils/contract_logs/payableExchangeIssuance.ts
@@ -2,7 +2,7 @@ import { Address, Log } from 'set-protocol-utils';
 import { BigNumber } from 'bignumber.js';
 
 export function LogPayableExchangeIssue(
-  setAddress: Address,
+  rebalancingSetAddress: Address,
   callerAddress: Address,
   etherQuantity: BigNumber,
   contractAddress: Address,
@@ -11,7 +11,7 @@ export function LogPayableExchangeIssue(
     event: 'LogPayableExchangeIssue',
     address: contractAddress,
     args: {
-      setAddress,
+      rebalancingSetAddress,
       callerAddress,
       etherQuantity,
     },
@@ -19,18 +19,18 @@ export function LogPayableExchangeIssue(
 }
 
 export function LogPayableExchangeRedeem(
-  setAddress: Address,
+  rebalancingSetAddress: Address,
   callerAddress: Address,
-  etherQuantity: BigNumber,
+  rebalancingSetQuantity: BigNumber,
   contractAddress: Address,
 ): Log[] {
   return [{
     event: 'LogPayableExchangeRedeem',
     address: contractAddress,
     args: {
-      setAddress,
+      rebalancingSetAddress,
       callerAddress,
-      etherQuantity,
+      rebalancingSetQuantity,
     },
   }];
 }

--- a/utils/contracts.ts
+++ b/utils/contracts.ts
@@ -8,6 +8,7 @@ import { CommonMathMockContract } from '../types/generated/common_math_mock';
 import { ConstantAuctionPriceCurveContract } from '../types/generated/constant_auction_price_curve';
 import { CoreContract } from '../types/generated/core';
 import { CoreIssuanceLibraryContract } from '../types/generated/core_issuance_library';
+import { CoreIssuanceLibraryMockContract } from '../types/generated/core_issuance_library_mock';
 import { CoreMockContract } from '../types/generated/core_mock';
 import { ERC20DetailedContract } from '../types/generated/erc20_detailed';
 import { ERC20WrapperContract } from '../types/generated/erc20_wrapper';
@@ -62,6 +63,7 @@ export {
   ConstantAuctionPriceCurveContract,
   CoreContract,
   CoreIssuanceLibraryContract,
+  CoreIssuanceLibraryMockContract,
   CoreMockContract,
   ERC20DetailedContract,
   ERC20WrapperContract,

--- a/utils/contracts.ts
+++ b/utils/contracts.ts
@@ -35,6 +35,8 @@ import { RebalancingSetTokenFactoryContract } from '../types/generated/rebalanci
 import { RebalancingTokenIssuanceModuleContract } from '../types/generated/rebalancing_token_issuance_module';
 import { SetTokenContract } from '../types/generated/set_token';
 import { SetTokenFactoryContract } from '../types/generated/set_token_factory';
+import { SetTokenLibraryContract } from '../types/generated/set_token_library';
+import { SetTokenLibraryMockContract } from '../types/generated/set_token_library_mock';
 import { StandardFailAuctionLibraryContract } from '../types/generated/standard_fail_auction_library';
 import { StandardPlaceBidLibraryContract } from '../types/generated/standard_place_bid_library';
 import { StandardProposeLibraryContract } from '../types/generated/standard_propose_library';
@@ -90,6 +92,8 @@ export {
   RebalancingTokenIssuanceModuleContract,
   SetTokenContract,
   SetTokenFactoryContract,
+  SetTokenLibraryContract,
+  SetTokenLibraryMockContract,
   StandardFailAuctionLibraryContract,
   StandardPlaceBidLibraryContract,
   StandardProposeLibraryContract,

--- a/utils/wrappers/coreWrapper.ts
+++ b/utils/wrappers/coreWrapper.ts
@@ -48,6 +48,7 @@ const RebalancingSetTokenFactory = artifacts.require('RebalancingSetTokenFactory
 const RebalancingTokenIssuanceModule = artifacts.require('RebalancingTokenIssuanceModule');
 const SetToken = artifacts.require('SetToken');
 const SetTokenFactory = artifacts.require('SetTokenFactory');
+const SetTokenLibrary = artifacts.require('SetTokenLibrary');
 const StandardFailAuctionLibrary = artifacts.require('StandardFailAuctionLibrary');
 const StandardPlaceBidLibrary = artifacts.require('StandardPlaceBidLibrary');
 const StandardProposeLibrary = artifacts.require('StandardProposeLibrary');
@@ -230,6 +231,16 @@ export class CoreWrapper {
       new web3.eth.Contract(truffleTokenFactory.abi, truffleTokenFactory.address),
       { from, gas: DEFAULT_GAS },
     );
+  }
+
+  public async linkSetTokenLibraryAsync(
+    contract: any,
+  ): Promise<void> {
+    const truffleSetTokenLibrary = await SetTokenLibrary.new(
+      { from: this._tokenOwnerAddress },
+    );
+
+    await contract.link('SetTokenLibrary', truffleSetTokenLibrary.address);
   }
 
   public async linkRebalancingLibrariesAsync(
@@ -435,6 +446,8 @@ export class CoreWrapper {
     vault: VaultContract,
     from: Address = this._tokenOwnerAddress
   ): Promise<ExchangeIssuanceModuleContract> {
+    await this.linkSetTokenLibraryAsync(ExchangeIssuanceModule);
+
     const truffleExchangeIssuanceModule = await ExchangeIssuanceModule.new(
       core.address,
       vault.address,

--- a/utils/wrappers/libraryMockWrapper.ts
+++ b/utils/wrappers/libraryMockWrapper.ts
@@ -5,6 +5,7 @@ import {
   CoreIssuanceLibraryMockContract,
   ERC20WrapperMockContract,
   ExchangeIssuanceLibraryMockContract,
+  SetTokenLibraryMockContract,
   ZeroExOrderLibraryMockContract
 } from '../contracts';
 import {
@@ -18,6 +19,8 @@ const ERC20WrapperMock = artifacts.require('ERC20WrapperMock');
 const Bytes32Mock = artifacts.require('Bytes32Mock');
 const CommonMathMock = artifacts.require('CommonMathMock');
 const ExchangeIssuanceLibraryMock = artifacts.require('ExchangeIssuanceLibraryMock');
+const SetTokenLibrary = artifacts.require('SetTokenLibrary');
+const SetTokenLibraryMock = artifacts.require('SetTokenLibraryMock');
 const ZeroExOrderLibraryMock = artifacts.require('ZeroExOrderLibraryMock');
 
 
@@ -97,6 +100,25 @@ export class LibraryMockWrapper {
 
     return new ERC20WrapperMockContract(
       new web3.eth.Contract(erc20WrapperMockContract.abi, erc20WrapperMockContract.address),
+      { from },
+    );
+  }
+
+  public async deploySetTokenLibraryAsync(
+    from: Address = this._contractOwnerAddress
+  ): Promise<SetTokenLibraryMockContract> {
+    const truffleSetTokenLibrary = await SetTokenLibrary.new(
+      { from: this._contractOwnerAddress },
+    );
+
+    await SetTokenLibraryMock.link('SetTokenLibrary', truffleSetTokenLibrary.address);
+
+    const setTokenLibraryMockContract = await SetTokenLibraryMock.new(
+      { from },
+    );
+
+    return new SetTokenLibraryMockContract(
+      new web3.eth.Contract(setTokenLibraryMockContract.abi, setTokenLibraryMockContract.address),
       { from },
     );
   }

--- a/utils/wrappers/libraryMockWrapper.ts
+++ b/utils/wrappers/libraryMockWrapper.ts
@@ -2,6 +2,7 @@ import { Address } from 'set-protocol-utils';
 import {
   Bytes32MockContract,
   CommonMathMockContract,
+  CoreIssuanceLibraryMockContract,
   ERC20WrapperMockContract,
   ExchangeIssuanceLibraryMockContract,
   ZeroExOrderLibraryMockContract
@@ -11,6 +12,8 @@ import {
 } from '../web3Helper';
 
 const web3 = getWeb3();
+const CoreIssuanceLibrary = artifacts.require('CoreIssuanceLibrary');
+const CoreIssuanceLibraryMock = artifacts.require('CoreIssuanceLibraryMock');
 const ERC20WrapperMock = artifacts.require('ERC20WrapperMock');
 const Bytes32Mock = artifacts.require('Bytes32Mock');
 const CommonMathMock = artifacts.require('CommonMathMock');
@@ -49,6 +52,25 @@ export class LibraryMockWrapper {
 
     return new CommonMathMockContract(
       new web3.eth.Contract(truffleCommonMathLibrary.abi, truffleCommonMathLibrary.address),
+      { from },
+    );
+  }
+
+  public async deployCoreIssuanceLibraryAsync(
+    from: Address = this._contractOwnerAddress
+  ): Promise<CoreIssuanceLibraryMockContract> {
+    const truffleCoreIssuanceLibrary = await CoreIssuanceLibrary.new(
+      { from: this._contractOwnerAddress },
+    );
+
+    await CoreIssuanceLibraryMock.link('CoreIssuanceLibrary', truffleCoreIssuanceLibrary.address);
+
+    const truffleCoreIssuanceLibraryMock = await CoreIssuanceLibraryMock.new(
+      { from },
+    );
+
+    return new CoreIssuanceLibraryMockContract(
+      new web3.eth.Contract(truffleCoreIssuanceLibraryMock.abi, truffleCoreIssuanceLibraryMock.address),
       { from },
     );
   }


### PR DESCRIPTION
- Check receive token duplicates
- Check quantity is a multiple of natural unit in CoreIssuanceLibrary
- Update `PayableExchangeRedeem` log to log rebalancing set quantity vs ether (which can be manipulated)
- Added `SetTokenLibrary` for setToken-related functions/validations
- Add unit testing