### PR TITLE
RedeemIntoEther: Return excess base Set to the user

### DIFF
--- a/contracts/core/modules/RebalancingSetExchangeIssuanceModule.sol
+++ b/contracts/core/modules/RebalancingSetExchangeIssuanceModule.sol
@@ -183,7 +183,7 @@ contract RebalancingSetExchangeIssuanceModule is
         );
 
         // Send excess base Set and ether to the user
-        returnExcessFunds(baseSetAddress);
+        returnIssuanceExcessFunds(baseSetAddress);
 
         emit LogPayableExchangeIssue(
             _rebalancingSetAddress,
@@ -250,7 +250,7 @@ contract RebalancingSetExchangeIssuanceModule is
         msg.sender.transfer(wethBalance);
 
         // Non-exchanged components are returned to the user
-        returnExcessBaseSetComponents(_exchangeIssuanceParams.setAddress);
+        returnRedemptionExcessFunds(_exchangeIssuanceParams.setAddress);
 
         emit LogPayableExchangeRedeem(
             _rebalancingSetAddress,
@@ -266,7 +266,7 @@ contract RebalancingSetExchangeIssuanceModule is
      *
      * @param _baseSetAddress    The address of the base Set
      */
-    function returnExcessFunds(
+    function returnIssuanceExcessFunds(
         address _baseSetAddress
     )
         private
@@ -358,28 +358,29 @@ contract RebalancingSetExchangeIssuanceModule is
             baseSet == _exchangeIssuanceParams.setAddress,
             "RebalancingSetExchangeIssuanceModule.validateRedeemInputs: Base Set addresses must match"
         );
-
-        // Quantity of base Set must be the same as in exchange issuance params
-        uint256 baseSetUnit = rebalancingSet.getUnits()[0];
-        uint256 rebalancingSetNaturalUnit = rebalancingSet.naturalUnit();
-        uint256 impliedBaseSetQuantity = _rebalancingSetQuantity
-            .mul(baseSetUnit)
-            .div(rebalancingSetNaturalUnit);
-        require(
-            impliedBaseSetQuantity == _exchangeIssuanceParams.quantity,
-            "RebalancingSetExchangeIssuanceModule.validateRedeemInputs: Base Set quantities must match"
-        );
     }
     /**
-     * Withdraw any non-exchanged components to the user
+     * Withdraw any remaining Base Set and non-exchanged components to the user
      *
      * @param  _setAddress   Address of the Base Set
      */
-    function returnExcessBaseSetComponents(
+    function returnRedemptionExcessFunds(
         address _setAddress
     )
         private
     {
+        // Return base Set if any that are in the Vault
+        uint256 baseSetQuantity = vaultInstance.getOwnerBalance(_setAddress, address(this));
+        if (baseSetQuantity > 0) {
+            coreInstance.withdrawModule(
+                address(this),
+                msg.sender,
+                _setAddress,
+                baseSetQuantity
+            );
+        }
+
+        // Return base Set components
         address[] memory baseSetComponents = ISetToken(_setAddress).getComponents();
         for (uint256 i = 0; i < baseSetComponents.length; i++) {
             uint256 withdrawQuantity = ERC20Wrapper.balanceOf(baseSetComponents[i], address(this));

--- a/test/contracts/core/modules/rebalancingSetExchangeIssuanceModule.spec.ts
+++ b/test/contracts/core/modules/rebalancingSetExchangeIssuanceModule.spec.ts
@@ -661,6 +661,51 @@ contract('RebalancingSetExchangeIssuanceModule', accounts => {
       });
     });
 
+    describe('when the implied base Set quantity is greater than the issuance params base Set quantity', async () => {
+      beforeEach(async () => {
+        // Generate wrapped Ether for the caller
+        await weth.deposit.sendTransactionAsync(
+          { from: tokenPurchaser, value: nonExchangedWethQuantity.toString(), gas: DEFAULT_GAS }
+        );
+
+        // Approve Weth to the transferProxy
+        await weth.approve.sendTransactionAsync(
+          transferProxy.address,
+          nonExchangedWethQuantity.mul(2),
+          { from: tokenPurchaser, gas: DEFAULT_GAS }
+        );
+
+        // Issue the Base Set to the vault
+        await core.issueInVault.sendTransactionAsync(
+          baseSetToken.address,
+          exchangeRedeemQuantity,
+          { from: tokenPurchaser, gas: DEFAULT_GAS }
+        );
+
+        // Issue the Rebalancing Set
+        const rebalancingSetQuantity = exchangeRedeemQuantity
+                                         .mul(DEFAULT_REBALANCING_NATURAL_UNIT)
+                                         .div(rebalancingUnitShares);
+        await core.issue.sendTransactionAsync(
+          rebalancingSetToken.address,
+          rebalancingSetQuantity,
+          { from: tokenPurchaser, gas: DEFAULT_GAS }
+        );
+
+        subjectRebalancingSetQuantity = subjectRebalancingSetQuantity.mul(2);
+      });
+
+      it('should return the excess base Set to the caller', async () => {
+        const previousReturnedAssetBalance = await baseSetToken.balanceOf.callAsync(subjectCaller);
+        const expectedReturnedAssetBalance = previousReturnedAssetBalance.add(exchangeRedeemQuantity);
+
+        await subject();
+
+        const currentReturnedAssetBalance = await baseSetToken.balanceOf.callAsync(subjectCaller);
+        expect(expectedReturnedAssetBalance).to.bignumber.equal(currentReturnedAssetBalance);
+      });
+    });
+
     describe('when the receive tokens length is greater than 1', async () => {
       beforeEach(async () => {
         subjectExchangeIssuanceParams.receiveTokens = [weth.address, weth.address];
@@ -686,16 +731,6 @@ contract('RebalancingSetExchangeIssuanceModule', accounts => {
     describe('when the base Set of the rebalancing Set is not the issuance params Set', async () => {
       beforeEach(async () => {
         subjectExchangeIssuanceParams.setAddress = weth.address;
-      });
-
-      it('should revert', async () => {
-        await expectRevertError(subject());
-      });
-    });
-
-    describe('when the base Set quantity is incongruent with the issuance params quantity', async () => {
-      beforeEach(async () => {
-        subjectExchangeIssuanceParams.quantity = exchangeRedeemQuantity.plus(1);
       });
 
       it('should revert', async () => {


### PR DESCRIPTION
Remove the check that base Set quantity must be the implied quantity from the rebalancing Set in favor of returning dust to the end user.