### PR TITLE
Brian/rebalance set issue updates

### DIFF
--- a/contracts/core/exchange-wrappers/KyberNetworkWrapper.sol
+++ b/contracts/core/exchange-wrappers/KyberNetworkWrapper.sol
@@ -163,7 +163,7 @@ contract KyberNetworkWrapper {
         }
 
         // Return leftover send tokens to the original caller
-        ExchangeWrapperLibrary.settleLeftoverSendTokens(
+        ExchangeWrapperLibrary.returnLeftoverSendTokens(
             sendTokens,
             _exchangeData.caller
         );

--- a/contracts/core/exchange-wrappers/KyberNetworkWrapper.sol
+++ b/contracts/core/exchange-wrappers/KyberNetworkWrapper.sol
@@ -163,7 +163,7 @@ contract KyberNetworkWrapper {
         }
 
         // Return leftover send tokens to the original caller
-        settleLeftoverSendTokens(
+        ExchangeWrapperLibrary.settleLeftoverSendTokens(
             sendTokens,
             _exchangeData.caller
         );
@@ -249,29 +249,5 @@ contract KyberNetworkWrapper {
         }
 
         return trade;
-    }
-
-    /**
-     * Checks if any maker tokens leftover and transfers to maker
-     * @param  _sendTokens    The addresses of send tokens
-     * @param  _caller        The address of the original transaction caller
-     */
-    function settleLeftoverSendTokens(
-        address[] memory _sendTokens,
-        address _caller
-    )
-        private
-    {
-        for (uint256 i = 0; i < _sendTokens.length; i++) {
-            // Transfer any unused or remainder send token back to the caller
-            uint256 remainderSendToken = ERC20Wrapper.balanceOf(_sendTokens[i], address(this));
-            if (remainderSendToken > 0) {
-                ERC20Wrapper.transfer(
-                    _sendTokens[i],
-                    _caller,
-                    remainderSendToken
-                );
-            }
-        }
     }
 }

--- a/contracts/core/exchange-wrappers/ZeroExExchangeWrapper.sol
+++ b/contracts/core/exchange-wrappers/ZeroExExchangeWrapper.sol
@@ -142,7 +142,7 @@ contract ZeroExExchangeWrapper {
         }
 
         // Return leftover send tokens to the original caller
-        ExchangeWrapperLibrary.settleLeftoverSendTokens(
+        ExchangeWrapperLibrary.returnLeftoverSendTokens(
             sendTokens,
             _exchangeData.caller
         );

--- a/contracts/core/lib/ExchangeWrapperLibrary.sol
+++ b/contracts/core/lib/ExchangeWrapperLibrary.sol
@@ -54,11 +54,11 @@ library ExchangeWrapperLibrary {
     }
 
     /**
-     * Checks if any maker tokens leftover and transfers to maker
+     * Checks if any send tokens leftover and transfers to caller
      * @param  _sendTokens    The addresses of send tokens
      * @param  _caller        The address of the original transaction caller
      */
-    function settleLeftoverSendTokens(
+    function returnLeftoverSendTokens(
         address[] memory _sendTokens,
         address _caller
     )

--- a/contracts/core/lib/ExchangeWrapperLibrary.sol
+++ b/contracts/core/lib/ExchangeWrapperLibrary.sol
@@ -19,6 +19,7 @@ pragma experimental "ABIEncoderV2";
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+import { ERC20Wrapper } from "../../lib/ERC20Wrapper.sol";
 import { ICore } from "../interfaces/ICore.sol";
 import { IExchangeWrapper } from "../interfaces/IExchangeWrapper.sol";
 import { LibBytes } from "../../external/0x/LibBytes.sol";
@@ -50,6 +51,30 @@ library ExchangeWrapperLibrary {
     struct ExchangeResults {
         address[] receiveTokens;
         uint256[] receiveTokenAmounts;
+    }
+
+    /**
+     * Checks if any maker tokens leftover and transfers to maker
+     * @param  _sendTokens    The addresses of send tokens
+     * @param  _caller        The address of the original transaction caller
+     */
+    function settleLeftoverSendTokens(
+        address[] memory _sendTokens,
+        address _caller
+    )
+        internal
+    {
+        for (uint256 i = 0; i < _sendTokens.length; i++) {
+            // Transfer any unused or remainder send token back to the caller
+            uint256 remainderSendToken = ERC20Wrapper.balanceOf(_sendTokens[i], address(this));
+            if (remainderSendToken > 0) {
+                ERC20Wrapper.transfer(
+                    _sendTokens[i],
+                    _caller,
+                    remainderSendToken
+                );
+            }
+        }
     }
 
     /**

--- a/contracts/core/modules/RebalancingSetExchangeIssuanceModule.sol
+++ b/contracts/core/modules/RebalancingSetExchangeIssuanceModule.sol
@@ -380,13 +380,13 @@ contract RebalancingSetExchangeIssuanceModule is
         // Require only 1 receive token
         require(
             _ethTokenArray.length == 1,
-            "RebalancingSetExchangeIssuanceModule.validateRedeemInputs: Only 1 Receive Token Allowed"
+            "RebalancingSetExchangeIssuanceModule.validateInputs: Only 1 Receive Token Allowed"
         );
 
         // Require receive token is weth
         require(
             weth == _ethTokenArray[0],
-            "RebalancingSetExchangeIssuanceModule.validateRedeemInputs: Receive token must be Weth"
+            "RebalancingSetExchangeIssuanceModule.validateInputs: Receive token must be Weth"
         );
 
         ISetToken rebalancingSet = ISetToken(_rebalancingSetAddress);
@@ -395,7 +395,7 @@ contract RebalancingSetExchangeIssuanceModule is
         address baseSet = rebalancingSet.getComponents()[0];
         require(
             baseSet == _collateralSetAddress,
-            "RebalancingSetExchangeIssuanceModule.validateRedeemInputs: Base Set addresses must match"
+            "RebalancingSetExchangeIssuanceModule.validateInputs: Base Set addresses must match"
         );
 
         ExchangeIssuanceLibrary.validateQuantity(

--- a/test/scenarios/rebalancing-set-exchange-issuance/rebalancingSetExchangeIssuanceScenarios.spec.ts
+++ b/test/scenarios/rebalancing-set-exchange-issuance/rebalancingSetExchangeIssuanceScenarios.spec.ts
@@ -92,6 +92,7 @@ contract('RebalancingSetExchangeIssuanceModule::Scenarios', accounts => {
   describe('#issueRebalancingSetWithEther: RB 50/50 BTCETH priced at $1', async () => {
     let subjectCaller: Address;
     let subjectRebalancingSetAddress: Address;
+    let subjectRebalancingSetQuantity: BigNumber;
     let subjectExchangeIssuanceParams: ExchangeIssuanceParams;
     let subjectExchangeOrdersData: Bytes;
     let subjectEther: BigNumber;
@@ -205,12 +206,16 @@ contract('RebalancingSetExchangeIssuanceModule::Scenarios', accounts => {
 
       subjectExchangeOrdersData = setUtils.generateSerializedOrders([zeroExOrder]);
       subjectRebalancingSetAddress = rebalancingSetToken.address;
+      subjectRebalancingSetQuantity = exchangeIssueQuantity
+                                        .div(rebalancingUnitShares)
+                                        .mul(DEFAULT_REBALANCING_NATURAL_UNIT);
       rebalancingSetQuantity = exchangeIssueQuantity.mul(DEFAULT_REBALANCING_NATURAL_UNIT).div(rebalancingUnitShares);
     });
 
     async function subject(): Promise<string> {
       return payableExchangeIssuance.issueRebalancingSetWithEther.sendTransactionAsync(
         subjectRebalancingSetAddress,
+        subjectRebalancingSetQuantity,
         subjectExchangeIssuanceParams,
         subjectExchangeOrdersData,
         { from: subjectCaller, gas: DEFAULT_GAS, value: subjectEther.toString() },


### PR DESCRIPTION
* Moved settleLeftoverTokens to ExchangeWrapperLibrary to be used as a standard in all exchangeWrappers
* Validate params inputs for both issue and redeem
* Require explicit definition of rebalancingSetQuantity for issue
* Clear any tokens traded for that exceed receiveTokenAmounts from rebalancingSetIssuanceOrderModule to caller